### PR TITLE
enhance(ui): limit the app max width 

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -1,3 +1,4 @@
+import 'package:app/core/presentation/widgets/app_limit_layout_builder_widget.dart';
 import 'package:app/i18n/i18n.g.dart';
 import 'package:app/router/app_router.dart';
 import 'package:app/theme/theme.dart';
@@ -14,11 +15,17 @@ class LemonadeApp extends StatelessWidget {
 
   Widget _portalBuilder(Widget child) => Portal(child: child);
 
+  Widget _limitAppLayoutBuilder(Widget child) => AppLimitLayoutBuilder(
+        child: child,
+      );
+
   @override
   Widget build(BuildContext context) {
-    return _translationProviderBuilder(
-      _portalBuilder(
-        _App(_appRouter),
+    return _limitAppLayoutBuilder(
+      _translationProviderBuilder(
+        _portalBuilder(
+          _App(_appRouter),
+        ),
       ),
     );
   }

--- a/lib/core/presentation/pages/event/events_listing_page.dart
+++ b/lib/core/presentation/pages/event/events_listing_page.dart
@@ -215,7 +215,10 @@ class _EventsListingViewState extends State<_EventsListingView> {
 
     return Expanded(
       child: Center(
-        child: Text(emptyText, textAlign: TextAlign.center,),
+        child: Text(
+          emptyText,
+          textAlign: TextAlign.center,
+        ),
       ),
     );
   }

--- a/lib/core/presentation/pages/event/widgets/event_card_widget.dart
+++ b/lib/core/presentation/pages/event/widgets/event_card_widget.dart
@@ -48,9 +48,9 @@ class EventCard extends StatelessWidget {
       );
 
   _buildCardBody() => event.newNewPhotosExpanded?.isNotEmpty == true
-      ? SizedBox(
+      ? Container(
+          constraints: BoxConstraints(maxHeight: 300),
           width: double.infinity,
-          // height: 200,
           child: CachedNetworkImage(
             width: double.infinity,
             fit: BoxFit.cover,

--- a/lib/core/presentation/widgets/app_limit_layout_builder_widget.dart
+++ b/lib/core/presentation/widgets/app_limit_layout_builder_widget.dart
@@ -1,0 +1,22 @@
+import 'package:flutter/material.dart';
+
+class AppLimitLayoutBuilder extends StatelessWidget {
+  final Widget child;
+  const AppLimitLayoutBuilder({
+    super.key,
+    required this.child,
+  });
+
+  double get _maxAppWidth => 650;
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Container(
+        color: Theme.of(context).colorScheme.primary,
+        constraints: BoxConstraints(maxWidth: _maxAppWidth),
+        child: child,
+      ),
+    );
+  }
+}


### PR DESCRIPTION
# What ? 
- App gets too big on the large device so we decide to limit the app width to 650 

# Screenshot
<img width="1348" alt="Screenshot 2023-07-03 at 14 17 14" src="https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/e234771e-04be-44bb-9d58-7d89fd21b011">
<img width="1063" alt="Screenshot 2023-07-03 at 14 17 16" src="https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/3eb0cd52-246b-452a-975c-eb2ae641a9da">
<img width="1063" alt="Screenshot 2023-07-03 at 14 19 49" src="https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/6cf18b7f-0f91-4a7f-a79e-aaa5c652a703">
