### PR TITLE
enhance: replace stream controller by using rxdart BehaviorSubject

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -114,6 +114,8 @@ PODS:
   - nanopb/decode (2.30909.0)
   - nanopb/encode (2.30909.0)
   - OrderedSet (5.0.0)
+  - package_info_plus (0.4.5):
+    - Flutter
   - path_provider_foundation (0.0.1):
     - Flutter
     - FlutterMacOS
@@ -121,6 +123,8 @@ PODS:
   - PromisesSwift (2.2.0):
     - PromisesObjC (= 2.2.0)
   - ReachabilitySwift (5.0.0)
+  - sensors_plus (0.0.1):
+    - Flutter
   - share_plus (0.0.1):
     - Flutter
   - sqflite (0.0.3):
@@ -141,7 +145,9 @@ DEPENDENCIES:
   - flutter_secure_storage (from `.symlinks/plugins/flutter_secure_storage/ios`)
   - flutter_web_auth_2 (from `.symlinks/plugins/flutter_web_auth_2/ios`)
   - geolocator_apple (from `.symlinks/plugins/geolocator_apple/ios`)
+  - package_info_plus (from `.symlinks/plugins/package_info_plus/ios`)
   - path_provider_foundation (from `.symlinks/plugins/path_provider_foundation/darwin`)
+  - sensors_plus (from `.symlinks/plugins/sensors_plus/ios`)
   - share_plus (from `.symlinks/plugins/share_plus/ios`)
   - sqflite (from `.symlinks/plugins/sqflite/ios`)
   - url_launcher_ios (from `.symlinks/plugins/url_launcher_ios/ios`)
@@ -189,8 +195,12 @@ EXTERNAL SOURCES:
     :path: ".symlinks/plugins/flutter_web_auth_2/ios"
   geolocator_apple:
     :path: ".symlinks/plugins/geolocator_apple/ios"
+  package_info_plus:
+    :path: ".symlinks/plugins/package_info_plus/ios"
   path_provider_foundation:
     :path: ".symlinks/plugins/path_provider_foundation/darwin"
+  sensors_plus:
+    :path: ".symlinks/plugins/sensors_plus/ios"
   share_plus:
     :path: ".symlinks/plugins/share_plus/ios"
   sqflite:
@@ -224,14 +234,16 @@ SPEC CHECKSUMS:
   GoogleUtilities: 9aa0ad5a7bc171f8bae016300bfcfa3fb8425749
   nanopb: b552cce312b6c8484180ef47159bc0f65a1f0431
   OrderedSet: aaeb196f7fef5a9edf55d89760da9176ad40b93c
+  package_info_plus: fd030dabf36271f146f1f3beacd48f564b0f17f7
   path_provider_foundation: eaf5b3e458fc0e5fbb9940fb09980e853fe058b8
   PromisesObjC: 09985d6d70fbe7878040aa746d78236e6946d2ef
   PromisesSwift: cf9eb58666a43bbe007302226e510b16c1e10959
   ReachabilitySwift: 985039c6f7b23a1da463388634119492ff86c825
+  sensors_plus: 5717760720f7e6acd96fdbd75b7428f5ad755ec2
   share_plus: 599aa54e4ea31d4b4c0e9c911bcc26c55e791028
   sqflite: 31f7eba61e3074736dff8807a9b41581e4f7f15a
   url_launcher_ios: 08a3dfac5fb39e8759aeb0abbd5d9480f30fc8b4
 
 PODFILE CHECKSUM: 6b9eb94e9f98a329f2ef624b852a6e42d090af2b
 
-COCOAPODS: 1.12.1
+COCOAPODS: 1.11.2

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -19,10 +19,7 @@ class LemonadeApp extends StatelessWidget {
   Widget _portalBuilder(Widget child) => Portal(child: child);
 
   Widget _globalBlocProviderBuilder(Widget child) => BlocProvider.value(
-        value: getIt<AuthBloc>()
-          ..add(
-            const AuthEvent.checkAuthenticated(),
-          ),
+        value: getIt<AuthBloc>(),
         child: child,
       );
 

--- a/lib/app.dart
+++ b/lib/app.dart
@@ -19,7 +19,10 @@ class LemonadeApp extends StatelessWidget {
   Widget _portalBuilder(Widget child) => Portal(child: child);
 
   Widget _globalBlocProviderBuilder(Widget child) => BlocProvider.value(
-        value: getIt<AuthBloc>()..add(const AuthEvent.checkAuthenticated()),
+        value: getIt<AuthBloc>()
+          ..add(
+            const AuthEvent.checkAuthenticated(),
+          ),
         child: child,
       );
 

--- a/lib/core/application/auth/auth_bloc.dart
+++ b/lib/core/application/auth/auth_bloc.dart
@@ -1,7 +1,7 @@
 import 'dart:async';
 
 import 'package:app/core/domain/auth/entities/auth_session.dart';
-import 'package:app/core/oauth.dart';
+import 'package:app/core/oauth/oauth.dart';
 import 'package:app/core/service/auth/auth_service.dart';
 import 'package:app/core/service/user/user_service.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -20,7 +20,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     required this.authService,
   }) : super(const AuthState.unknown()) {
     _tokenStateSubscription = authService.tokenStateStream.listen(_onTokenStateChange);
-    on<AuthEventCheckAuthenticated>(_onCheckAuthenticated);
     on<AuthEventLogin>(_onLogin);
     on<AuthEventLogout>(_onLogout);
     on<AuthEventAuthenticated>(_onAuthenticated);
@@ -56,10 +55,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
     emit(const AuthState.unauthenticated(isChecking: false));
   }
 
-  _onCheckAuthenticated(AuthEventCheckAuthenticated event, Emitter emit) async {
-    await authService.checkAuthenticated();
-  }
-
   _onLogin(AuthEventLogin event, Emitter emit) async {
     await authService.login();
   }
@@ -78,7 +73,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
 class AuthEvent with _$AuthEvent {
   const factory AuthEvent.login() = AuthEventLogin;
   const factory AuthEvent.logout() = AuthEventLogout;
-  const factory AuthEvent.checkAuthenticated() = AuthEventCheckAuthenticated;
   const factory AuthEvent.authenticated() = AuthEventAuthenticated;
   const factory AuthEvent.unauthenticated() = AuthEventUnAuthenticated;
 }

--- a/lib/core/application/auth/auth_bloc.dart
+++ b/lib/core/application/auth/auth_bloc.dart
@@ -30,7 +30,6 @@ class AuthBloc extends Bloc<AuthEvent, AuthState> {
   @override
   Future<void> close() async {
     await _tokenStateSubscription?.cancel();
-    await authService.close();
     super.close();
   }
 

--- a/lib/core/application/auth/auth_bloc.freezed.dart
+++ b/lib/core/application/auth/auth_bloc.freezed.dart
@@ -20,7 +20,6 @@ mixin _$AuthEvent {
   TResult when<TResult extends Object?>({
     required TResult Function() login,
     required TResult Function() logout,
-    required TResult Function() checkAuthenticated,
     required TResult Function() authenticated,
     required TResult Function() unauthenticated,
   }) =>
@@ -29,7 +28,6 @@ mixin _$AuthEvent {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? login,
     TResult? Function()? logout,
-    TResult? Function()? checkAuthenticated,
     TResult? Function()? authenticated,
     TResult? Function()? unauthenticated,
   }) =>
@@ -38,7 +36,6 @@ mixin _$AuthEvent {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? login,
     TResult Function()? logout,
-    TResult Function()? checkAuthenticated,
     TResult Function()? authenticated,
     TResult Function()? unauthenticated,
     required TResult orElse(),
@@ -48,8 +45,6 @@ mixin _$AuthEvent {
   TResult map<TResult extends Object?>({
     required TResult Function(AuthEventLogin value) login,
     required TResult Function(AuthEventLogout value) logout,
-    required TResult Function(AuthEventCheckAuthenticated value)
-        checkAuthenticated,
     required TResult Function(AuthEventAuthenticated value) authenticated,
     required TResult Function(AuthEventUnAuthenticated value) unauthenticated,
   }) =>
@@ -58,7 +53,6 @@ mixin _$AuthEvent {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(AuthEventLogin value)? login,
     TResult? Function(AuthEventLogout value)? logout,
-    TResult? Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult? Function(AuthEventAuthenticated value)? authenticated,
     TResult? Function(AuthEventUnAuthenticated value)? unauthenticated,
   }) =>
@@ -67,7 +61,6 @@ mixin _$AuthEvent {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(AuthEventLogin value)? login,
     TResult Function(AuthEventLogout value)? logout,
-    TResult Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult Function(AuthEventAuthenticated value)? authenticated,
     TResult Function(AuthEventUnAuthenticated value)? unauthenticated,
     required TResult orElse(),
@@ -132,7 +125,6 @@ class _$AuthEventLogin implements AuthEventLogin {
   TResult when<TResult extends Object?>({
     required TResult Function() login,
     required TResult Function() logout,
-    required TResult Function() checkAuthenticated,
     required TResult Function() authenticated,
     required TResult Function() unauthenticated,
   }) {
@@ -144,7 +136,6 @@ class _$AuthEventLogin implements AuthEventLogin {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? login,
     TResult? Function()? logout,
-    TResult? Function()? checkAuthenticated,
     TResult? Function()? authenticated,
     TResult? Function()? unauthenticated,
   }) {
@@ -156,7 +147,6 @@ class _$AuthEventLogin implements AuthEventLogin {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? login,
     TResult Function()? logout,
-    TResult Function()? checkAuthenticated,
     TResult Function()? authenticated,
     TResult Function()? unauthenticated,
     required TResult orElse(),
@@ -172,8 +162,6 @@ class _$AuthEventLogin implements AuthEventLogin {
   TResult map<TResult extends Object?>({
     required TResult Function(AuthEventLogin value) login,
     required TResult Function(AuthEventLogout value) logout,
-    required TResult Function(AuthEventCheckAuthenticated value)
-        checkAuthenticated,
     required TResult Function(AuthEventAuthenticated value) authenticated,
     required TResult Function(AuthEventUnAuthenticated value) unauthenticated,
   }) {
@@ -185,7 +173,6 @@ class _$AuthEventLogin implements AuthEventLogin {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(AuthEventLogin value)? login,
     TResult? Function(AuthEventLogout value)? logout,
-    TResult? Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult? Function(AuthEventAuthenticated value)? authenticated,
     TResult? Function(AuthEventUnAuthenticated value)? unauthenticated,
   }) {
@@ -197,7 +184,6 @@ class _$AuthEventLogin implements AuthEventLogin {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(AuthEventLogin value)? login,
     TResult Function(AuthEventLogout value)? logout,
-    TResult Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult Function(AuthEventAuthenticated value)? authenticated,
     TResult Function(AuthEventUnAuthenticated value)? unauthenticated,
     required TResult orElse(),
@@ -253,7 +239,6 @@ class _$AuthEventLogout implements AuthEventLogout {
   TResult when<TResult extends Object?>({
     required TResult Function() login,
     required TResult Function() logout,
-    required TResult Function() checkAuthenticated,
     required TResult Function() authenticated,
     required TResult Function() unauthenticated,
   }) {
@@ -265,7 +250,6 @@ class _$AuthEventLogout implements AuthEventLogout {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? login,
     TResult? Function()? logout,
-    TResult? Function()? checkAuthenticated,
     TResult? Function()? authenticated,
     TResult? Function()? unauthenticated,
   }) {
@@ -277,7 +261,6 @@ class _$AuthEventLogout implements AuthEventLogout {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? login,
     TResult Function()? logout,
-    TResult Function()? checkAuthenticated,
     TResult Function()? authenticated,
     TResult Function()? unauthenticated,
     required TResult orElse(),
@@ -293,8 +276,6 @@ class _$AuthEventLogout implements AuthEventLogout {
   TResult map<TResult extends Object?>({
     required TResult Function(AuthEventLogin value) login,
     required TResult Function(AuthEventLogout value) logout,
-    required TResult Function(AuthEventCheckAuthenticated value)
-        checkAuthenticated,
     required TResult Function(AuthEventAuthenticated value) authenticated,
     required TResult Function(AuthEventUnAuthenticated value) unauthenticated,
   }) {
@@ -306,7 +287,6 @@ class _$AuthEventLogout implements AuthEventLogout {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(AuthEventLogin value)? login,
     TResult? Function(AuthEventLogout value)? logout,
-    TResult? Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult? Function(AuthEventAuthenticated value)? authenticated,
     TResult? Function(AuthEventUnAuthenticated value)? unauthenticated,
   }) {
@@ -318,7 +298,6 @@ class _$AuthEventLogout implements AuthEventLogout {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(AuthEventLogin value)? login,
     TResult Function(AuthEventLogout value)? logout,
-    TResult Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult Function(AuthEventAuthenticated value)? authenticated,
     TResult Function(AuthEventUnAuthenticated value)? unauthenticated,
     required TResult orElse(),
@@ -332,130 +311,6 @@ class _$AuthEventLogout implements AuthEventLogout {
 
 abstract class AuthEventLogout implements AuthEvent {
   const factory AuthEventLogout() = _$AuthEventLogout;
-}
-
-/// @nodoc
-abstract class _$$AuthEventCheckAuthenticatedCopyWith<$Res> {
-  factory _$$AuthEventCheckAuthenticatedCopyWith(
-          _$AuthEventCheckAuthenticated value,
-          $Res Function(_$AuthEventCheckAuthenticated) then) =
-      __$$AuthEventCheckAuthenticatedCopyWithImpl<$Res>;
-}
-
-/// @nodoc
-class __$$AuthEventCheckAuthenticatedCopyWithImpl<$Res>
-    extends _$AuthEventCopyWithImpl<$Res, _$AuthEventCheckAuthenticated>
-    implements _$$AuthEventCheckAuthenticatedCopyWith<$Res> {
-  __$$AuthEventCheckAuthenticatedCopyWithImpl(
-      _$AuthEventCheckAuthenticated _value,
-      $Res Function(_$AuthEventCheckAuthenticated) _then)
-      : super(_value, _then);
-}
-
-/// @nodoc
-
-class _$AuthEventCheckAuthenticated implements AuthEventCheckAuthenticated {
-  const _$AuthEventCheckAuthenticated();
-
-  @override
-  String toString() {
-    return 'AuthEvent.checkAuthenticated()';
-  }
-
-  @override
-  bool operator ==(dynamic other) {
-    return identical(this, other) ||
-        (other.runtimeType == runtimeType &&
-            other is _$AuthEventCheckAuthenticated);
-  }
-
-  @override
-  int get hashCode => runtimeType.hashCode;
-
-  @override
-  @optionalTypeArgs
-  TResult when<TResult extends Object?>({
-    required TResult Function() login,
-    required TResult Function() logout,
-    required TResult Function() checkAuthenticated,
-    required TResult Function() authenticated,
-    required TResult Function() unauthenticated,
-  }) {
-    return checkAuthenticated();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? whenOrNull<TResult extends Object?>({
-    TResult? Function()? login,
-    TResult? Function()? logout,
-    TResult? Function()? checkAuthenticated,
-    TResult? Function()? authenticated,
-    TResult? Function()? unauthenticated,
-  }) {
-    return checkAuthenticated?.call();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeWhen<TResult extends Object?>({
-    TResult Function()? login,
-    TResult Function()? logout,
-    TResult Function()? checkAuthenticated,
-    TResult Function()? authenticated,
-    TResult Function()? unauthenticated,
-    required TResult orElse(),
-  }) {
-    if (checkAuthenticated != null) {
-      return checkAuthenticated();
-    }
-    return orElse();
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult map<TResult extends Object?>({
-    required TResult Function(AuthEventLogin value) login,
-    required TResult Function(AuthEventLogout value) logout,
-    required TResult Function(AuthEventCheckAuthenticated value)
-        checkAuthenticated,
-    required TResult Function(AuthEventAuthenticated value) authenticated,
-    required TResult Function(AuthEventUnAuthenticated value) unauthenticated,
-  }) {
-    return checkAuthenticated(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult? mapOrNull<TResult extends Object?>({
-    TResult? Function(AuthEventLogin value)? login,
-    TResult? Function(AuthEventLogout value)? logout,
-    TResult? Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
-    TResult? Function(AuthEventAuthenticated value)? authenticated,
-    TResult? Function(AuthEventUnAuthenticated value)? unauthenticated,
-  }) {
-    return checkAuthenticated?.call(this);
-  }
-
-  @override
-  @optionalTypeArgs
-  TResult maybeMap<TResult extends Object?>({
-    TResult Function(AuthEventLogin value)? login,
-    TResult Function(AuthEventLogout value)? logout,
-    TResult Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
-    TResult Function(AuthEventAuthenticated value)? authenticated,
-    TResult Function(AuthEventUnAuthenticated value)? unauthenticated,
-    required TResult orElse(),
-  }) {
-    if (checkAuthenticated != null) {
-      return checkAuthenticated(this);
-    }
-    return orElse();
-  }
-}
-
-abstract class AuthEventCheckAuthenticated implements AuthEvent {
-  const factory AuthEventCheckAuthenticated() = _$AuthEventCheckAuthenticated;
 }
 
 /// @nodoc
@@ -498,7 +353,6 @@ class _$AuthEventAuthenticated implements AuthEventAuthenticated {
   TResult when<TResult extends Object?>({
     required TResult Function() login,
     required TResult Function() logout,
-    required TResult Function() checkAuthenticated,
     required TResult Function() authenticated,
     required TResult Function() unauthenticated,
   }) {
@@ -510,7 +364,6 @@ class _$AuthEventAuthenticated implements AuthEventAuthenticated {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? login,
     TResult? Function()? logout,
-    TResult? Function()? checkAuthenticated,
     TResult? Function()? authenticated,
     TResult? Function()? unauthenticated,
   }) {
@@ -522,7 +375,6 @@ class _$AuthEventAuthenticated implements AuthEventAuthenticated {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? login,
     TResult Function()? logout,
-    TResult Function()? checkAuthenticated,
     TResult Function()? authenticated,
     TResult Function()? unauthenticated,
     required TResult orElse(),
@@ -538,8 +390,6 @@ class _$AuthEventAuthenticated implements AuthEventAuthenticated {
   TResult map<TResult extends Object?>({
     required TResult Function(AuthEventLogin value) login,
     required TResult Function(AuthEventLogout value) logout,
-    required TResult Function(AuthEventCheckAuthenticated value)
-        checkAuthenticated,
     required TResult Function(AuthEventAuthenticated value) authenticated,
     required TResult Function(AuthEventUnAuthenticated value) unauthenticated,
   }) {
@@ -551,7 +401,6 @@ class _$AuthEventAuthenticated implements AuthEventAuthenticated {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(AuthEventLogin value)? login,
     TResult? Function(AuthEventLogout value)? logout,
-    TResult? Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult? Function(AuthEventAuthenticated value)? authenticated,
     TResult? Function(AuthEventUnAuthenticated value)? unauthenticated,
   }) {
@@ -563,7 +412,6 @@ class _$AuthEventAuthenticated implements AuthEventAuthenticated {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(AuthEventLogin value)? login,
     TResult Function(AuthEventLogout value)? logout,
-    TResult Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult Function(AuthEventAuthenticated value)? authenticated,
     TResult Function(AuthEventUnAuthenticated value)? unauthenticated,
     required TResult orElse(),
@@ -620,7 +468,6 @@ class _$AuthEventUnAuthenticated implements AuthEventUnAuthenticated {
   TResult when<TResult extends Object?>({
     required TResult Function() login,
     required TResult Function() logout,
-    required TResult Function() checkAuthenticated,
     required TResult Function() authenticated,
     required TResult Function() unauthenticated,
   }) {
@@ -632,7 +479,6 @@ class _$AuthEventUnAuthenticated implements AuthEventUnAuthenticated {
   TResult? whenOrNull<TResult extends Object?>({
     TResult? Function()? login,
     TResult? Function()? logout,
-    TResult? Function()? checkAuthenticated,
     TResult? Function()? authenticated,
     TResult? Function()? unauthenticated,
   }) {
@@ -644,7 +490,6 @@ class _$AuthEventUnAuthenticated implements AuthEventUnAuthenticated {
   TResult maybeWhen<TResult extends Object?>({
     TResult Function()? login,
     TResult Function()? logout,
-    TResult Function()? checkAuthenticated,
     TResult Function()? authenticated,
     TResult Function()? unauthenticated,
     required TResult orElse(),
@@ -660,8 +505,6 @@ class _$AuthEventUnAuthenticated implements AuthEventUnAuthenticated {
   TResult map<TResult extends Object?>({
     required TResult Function(AuthEventLogin value) login,
     required TResult Function(AuthEventLogout value) logout,
-    required TResult Function(AuthEventCheckAuthenticated value)
-        checkAuthenticated,
     required TResult Function(AuthEventAuthenticated value) authenticated,
     required TResult Function(AuthEventUnAuthenticated value) unauthenticated,
   }) {
@@ -673,7 +516,6 @@ class _$AuthEventUnAuthenticated implements AuthEventUnAuthenticated {
   TResult? mapOrNull<TResult extends Object?>({
     TResult? Function(AuthEventLogin value)? login,
     TResult? Function(AuthEventLogout value)? logout,
-    TResult? Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult? Function(AuthEventAuthenticated value)? authenticated,
     TResult? Function(AuthEventUnAuthenticated value)? unauthenticated,
   }) {
@@ -685,7 +527,6 @@ class _$AuthEventUnAuthenticated implements AuthEventUnAuthenticated {
   TResult maybeMap<TResult extends Object?>({
     TResult Function(AuthEventLogin value)? login,
     TResult Function(AuthEventLogout value)? logout,
-    TResult Function(AuthEventCheckAuthenticated value)? checkAuthenticated,
     TResult Function(AuthEventAuthenticated value)? authenticated,
     TResult Function(AuthEventUnAuthenticated value)? unauthenticated,
     required TResult orElse(),

--- a/lib/core/data/user/user_repository_impl.dart
+++ b/lib/core/data/user/user_repository_impl.dart
@@ -20,7 +20,6 @@ class UserRepositoryImpl implements UserRepository {
       parserFn: (data) {
         return AuthUser.fromDto(UserDto.fromJson(data['getMe']));
       },
-      fetchPolicy: FetchPolicy.networkOnly,
     ));
 
     if (result.hasException) return Left(Failure());

--- a/lib/core/gql.dart
+++ b/lib/core/gql.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:app/core/config.dart';
 import 'package:app/core/oauth.dart';
 import 'package:app/injection/register_module.dart';
@@ -5,16 +7,13 @@ import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:injectable/injectable.dart';
 
 class BaseGQL {
+  final appOauth = getIt<AppOauth>();
   final String httpUrl;
   final String wssUrl;
-
-  final appOauth = getIt<AppOauth>();
-
+  late final StreamSubscription<OAuthTokenState> tokenStateSubscription;
   late final GraphQLClient _client;
   late final AuthLink _authLink;
-
   late final HttpLink _httpLink = HttpLink(httpUrl);
-
   late final WebSocketLink _webSocketLink = WebSocketLink(
     wssUrl,
     config: SocketClientConfig(
@@ -47,6 +46,16 @@ class BaseGQL {
       ),
       cache: GraphQLCache(store: HiveStore()),
     );
+
+    tokenStateSubscription = appOauth.tokenStateStream.listen((tokenState) {
+        if(tokenState == OAuthTokenState.invalid) {
+          _client.resetStore();
+        }
+    });
+  }
+
+  Future<void> dispose() async {
+    await tokenStateSubscription.cancel();
   }
 }
 

--- a/lib/core/gql.dart
+++ b/lib/core/gql.dart
@@ -1,8 +1,9 @@
 import 'dart:async';
 
 import 'package:app/core/config.dart';
-import 'package:app/core/oauth.dart';
+import 'package:app/core/oauth/oauth.dart';
 import 'package:app/injection/register_module.dart';
+import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:graphql_flutter/graphql_flutter.dart';
 import 'package:injectable/injectable.dart';
 
@@ -13,14 +14,13 @@ class BaseGQL {
   late final StreamSubscription<OAuthTokenState> tokenStateSubscription;
   late final GraphQLClient _client;
   late final AuthLink _authLink;
+  late final ErrorLink _errorLink;
   late final HttpLink _httpLink = HttpLink(httpUrl);
-  late final WebSocketLink _webSocketLink = WebSocketLink(
-    wssUrl,
-    config: SocketClientConfig(
-      autoReconnect: true,
-    ),
-    subProtocol: GraphQLProtocol.graphqlTransportWs
-  );
+  late final WebSocketLink _webSocketLink = WebSocketLink(wssUrl,
+      config: SocketClientConfig(
+        autoReconnect: true,
+      ),
+      subProtocol: GraphQLProtocol.graphqlTransportWs);
 
   GraphQLClient get client => _client;
 
@@ -31,26 +31,39 @@ class BaseGQL {
     _authLink = AuthLink(getToken: () async {
       return await appOauth.getTokenForGql();
     });
-
+    _errorLink = ErrorLink(
+      onException: (request, forward, exception) {
+        FirebaseCrashlytics.instance.log(exception.toString());
+        return null;
+      },
+      onGraphQLError: (request, forward, response) {
+        FirebaseCrashlytics.instance.log(response.errors.toString());
+        return null;
+      },
+    );
+    
     _client = GraphQLClient(
       defaultPolicies: DefaultPolicies(
           query: Policies(
         fetch: FetchPolicy.cacheAndNetwork,
       )),
-      link: _authLink.split(
-        (request) {
-          return request.isSubscription;
-        },
-        _webSocketLink,
-        _httpLink,
-      ),
+      link: Link.from([
+        _errorLink,
+        _authLink.split(
+          (request) {
+            return request.isSubscription;
+          },
+          _webSocketLink,
+          _httpLink,
+        )
+      ]),
       cache: GraphQLCache(store: HiveStore()),
     );
 
     tokenStateSubscription = appOauth.tokenStateStream.listen((tokenState) {
-        if(tokenState == OAuthTokenState.invalid) {
-          _client.resetStore();
-        }
+      if (tokenState == OAuthTokenState.invalid) {
+        _client.resetStore();
+      }
     });
   }
 

--- a/lib/core/oauth.dart
+++ b/lib/core/oauth.dart
@@ -134,7 +134,7 @@ class AppOauth {
 
 
   AccessTokenResponse? _processTokenState(AccessTokenResponse? token) {
-    if (token == null || !token.isValid()) {
+    if (token == null || !token.isValid() || token.isExpired())  {
       _reset();
     } else {
       _updateTokenState(OAuthTokenState.valid);

--- a/lib/core/oauth.dart
+++ b/lib/core/oauth.dart
@@ -8,12 +8,17 @@ import 'package:injectable/injectable.dart';
 import 'package:oauth2_client/access_token_response.dart';
 import 'package:oauth2_client/oauth2_client.dart';
 import 'package:oauth2_client/oauth2_helper.dart';
+import 'package:rxdart/rxdart.dart';
 
 class OauthError {
   static String userCancelled = 'org.openid.appauth.general error -3';
 }
 
-enum OAuthTokenState { valid, invalidOrEmpty }
+enum OAuthTokenState {
+  unknown,
+  valid,
+  invalid,
+}
 
 @lazySingleton
 class AppOauth {
@@ -24,8 +29,8 @@ class AppOauth {
   late final logoutRedirectUri = '$appUriScheme://oauth2/logout';
   final scopes = ['openid', 'offline_access'];
 
-  final StreamController<OAuthTokenState> _tokenStateStreamCtrl = StreamController();
-  OAuthTokenState _tokenState = OAuthTokenState.invalidOrEmpty;
+  final BehaviorSubject<OAuthTokenState> _tokenStateStreamCtrl = BehaviorSubject();
+  OAuthTokenState _tokenState = OAuthTokenState.unknown;
 
   Future<String>? refreshTokenFuture;
 
@@ -123,9 +128,8 @@ class AppOauth {
   }
 
   Future<void> _reset() async {
-    if (_tokenState == OAuthTokenState.invalidOrEmpty) return;
     await helper.removeAllTokens();
-    _updateTokenState(OAuthTokenState.invalidOrEmpty);
+    _updateTokenState(OAuthTokenState.invalid);
   }
 
 

--- a/lib/core/oauth/custom_oauth_helper.dart
+++ b/lib/core/oauth/custom_oauth_helper.dart
@@ -19,6 +19,9 @@ class CustomOAuth2Helper extends OAuth2Helper {
           accessTokenHeaders: {
             "Content-Type": "application/x-www-form-urlencoded",
           },
+          webAuthOpts: {
+            'preferEphemeral': true,
+          }
         );
 
   @override

--- a/lib/core/oauth/custom_oauth_helper.dart
+++ b/lib/core/oauth/custom_oauth_helper.dart
@@ -1,0 +1,88 @@
+import 'package:oauth2_client/access_token_response.dart';
+import 'package:oauth2_client/oauth2_client.dart';
+import 'package:oauth2_client/oauth2_exception.dart';
+import 'package:oauth2_client/oauth2_helper.dart';
+
+class CustomOAuth2Helper extends OAuth2Helper {
+  final OAuth2Client client;
+  final String clientId;
+  final List<String> scopes;
+
+  CustomOAuth2Helper(
+    this.client, {
+    required this.clientId,
+    required this.scopes,
+  }) : super(
+          client,
+          clientId: clientId,
+          scopes: scopes,
+          accessTokenHeaders: {
+            "Content-Type": "application/x-www-form-urlencoded",
+          },
+        );
+
+  @override
+  Future<AccessTokenResponse?> getToken() async {
+    _validateAuthorizationParams();
+    var tknResp = await getTokenFromStorage();
+
+    if (tknResp != null) {
+      if (tknResp.refreshNeeded()) {
+        //The access token is expired
+        if (tknResp.hasRefreshToken()) {
+          tknResp = await refreshToken(tknResp);
+        }
+      }
+
+      if (!tknResp.isValid()) {
+        throw Exception('Provider error ${tknResp.httpStatusCode}: ${tknResp.error}: ${tknResp.errorDescription}');
+      }
+
+      if (!tknResp.isBearer()) {
+        throw Exception('Only Bearer tokens are currently supported');
+      }
+    }
+
+    return tknResp;
+  }
+
+  Future<AccessTokenResponse> refreshToken(AccessTokenResponse curTknResp) async {
+    AccessTokenResponse? tknResp;
+    var refreshToken = curTknResp.refreshToken!;
+    try {
+      tknResp = await client.refreshToken(
+        refreshToken,
+        clientId: clientId,
+        clientSecret: clientSecret,
+        scopes: curTknResp.scope,
+      );
+      if (tknResp.isValid()) {
+        //If the response doesn't contain a refresh token, keep using the current one
+        if (!tknResp.hasRefreshToken()) {
+          tknResp.refreshToken = refreshToken;
+        }
+        await tokenStorage.addToken(tknResp);
+      } else {
+        if (tknResp.error == 'invalid_grant') {
+          //The refresh token is expired too
+          await tokenStorage.deleteToken(scopes);
+        } else {
+          throw OAuth2Exception(tknResp.error ?? 'Error', errorDescription: tknResp.errorDescription);
+        }
+      }
+      return tknResp;
+    } catch (_) {
+      throw Exception("Refresh token fail");
+    }
+  }
+
+  void _validateAuthorizationParams() {
+    if (clientId.isEmpty) {
+      throw Exception('Required "clientId" parameter not set');
+    }
+
+    if (grantType == OAuth2Helper.clientCredentials && (clientSecret == null || clientSecret!.isEmpty)) {
+      throw Exception('Required "clientSecret" parameter not set');
+    }
+  }
+}

--- a/lib/core/oauth/oauth.dart
+++ b/lib/core/oauth/oauth.dart
@@ -99,6 +99,10 @@ class AppOauth {
     }
   }
 
+  Future<void> forceLogout() async {
+    _reset();
+  }
+
   Future<AccessTokenResponse?> manuallyRefreshToken(AccessTokenResponse tokenResponse) async =>
       helper.refreshToken(tokenResponse);
 

--- a/lib/core/oauth/oauth.dart
+++ b/lib/core/oauth/oauth.dart
@@ -1,13 +1,13 @@
 import 'dart:async';
 
 import 'package:app/core/config.dart';
+import 'package:app/core/oauth/custom_oauth_helper.dart';
 import 'package:dartz/dartz.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:injectable/injectable.dart';
 import 'package:oauth2_client/access_token_response.dart';
 import 'package:oauth2_client/oauth2_client.dart';
-import 'package:oauth2_client/oauth2_helper.dart';
 import 'package:rxdart/rxdart.dart';
 
 class OauthError {
@@ -44,102 +44,111 @@ class AppOauth {
     customUriScheme: appUriScheme,
   );
 
-  late final OAuth2Helper helper = OAuth2Helper(client,
-      clientId: clientId,
-      accessTokenHeaders: {
-        "Content-Type": "application/x-www-form-urlencoded",
-      },
-      scopes: scopes);
+  late final CustomOAuth2Helper helper = CustomOAuth2Helper(
+    client,
+    clientId: clientId,
+    scopes: scopes,
+  );
+
+  AppOauth() {
+    init();
+  }
+
+  init() async {
+    await _checkTokenState();
+  }
 
   Future<Either<Exception, bool>> login() async {
     try {
-      var res = _processTokenState(await helper.fetchToken());
-      return Right(res?.accessToken != null);
+      var res = await _processTokenState(helper.fetchToken());
+      if (res?.isValid() == true) {
+        return Right(true);
+      }
+      return Left(Exception(res?.error));
     } on PlatformException catch (e) {
       _reset();
       return Left(e);
     }
   }
 
-  Future<bool> logout() async {
+  Future<Either<Exception, bool>> logout() async {
     try {
-      final tknRes = await getTokenFromStorage();
-      await const FlutterAppAuth().endSession(EndSessionRequest(
+      final tknRes = await helper.getTokenFromStorage();
+      await const FlutterAppAuth().endSession(
+        EndSessionRequest(
           idTokenHint: tknRes?.getRespField('id_token'),
           postLogoutRedirectUrl: logoutRedirectUri,
           serviceConfiguration: AuthorizationServiceConfiguration(
             authorizationEndpoint: client.authorizeUrl,
             tokenEndpoint: client.tokenUrl,
             endSessionEndpoint: client.revokeUrl,
-          )));
+          ),
+        ),
+      );
       await _reset();
-      return true;
+      return Right(true);
     } on PlatformException catch (e) {
       if (e.message?.contains(OauthError.userCancelled) == true) {
-        return false;
+        return Left(e);
       }
       await _reset();
-      return true;
+      return Right(true);
     } catch (error) {
       await _reset();
-      return true;
+      return Right(true);
     }
   }
 
-  Future<AccessTokenResponse?> manuallyRefreshToken() async {
-    AccessTokenResponse? tokenRes;
-    var curTokenRes = await getTokenFromStorage();
+  Future<AccessTokenResponse?> manuallyRefreshToken(AccessTokenResponse tokenResponse) async =>
+      helper.refreshToken(tokenResponse);
 
-    if (curTokenRes == null) return null;
+  Future<AccessTokenResponse?> getTokenFromStorage() => helper.getTokenFromStorage();
 
-    tokenRes = await helper.refreshToken(curTokenRes);
-
-    return _processTokenState(tokenRes);
-  }
-
-  Future<AccessTokenResponse?> getTokenFromStorage() async {
-    return _processTokenState(await helper.getTokenFromStorage());
-  }
-
-  Future<AccessTokenResponse?> getToken() async {
-    return _processTokenState(await helper.getToken());
-  }
+  Future<AccessTokenResponse?> getToken() async => helper.getToken();
 
   Future<String> getTokenForGql() async {
     AccessTokenResponse? tokenRes;
     tokenRes = await getTokenFromStorage();
     if (tokenRes == null) return '';
-    if (tokenRes.isExpired()) {
+    if (tokenRes.refreshNeeded() || tokenRes.isExpired()) {
       // if token is expired, all coming request have to wait only one refresh token request
       // prevent duplicate call refresh token
-      refreshTokenFuture ??= getToken().then((_tokenRes) {
+      refreshTokenFuture ??= getToken().then((_tokenRes) async {
+        _processTokenState(Future.value(_tokenRes));
         refreshTokenFuture = null;
         return _tokenRes?.accessToken != null ? 'Bearer ${tokenRes?.accessToken}' : '';
+      }).catchError((e) {
+        _reset();
+        return '';
       });
       return refreshTokenFuture!;
     }
-    tokenRes = await getToken();
-
-    return tokenRes?.accessToken != null ? 'Bearer ${tokenRes?.accessToken}' : '';
+    _processTokenState(Future.value(tokenRes));
+    return tokenRes.accessToken != null ? 'Bearer ${tokenRes.accessToken}' : '';
   }
 
-  Future<void> dispose() async {
-    await _tokenStateStreamCtrl.close();
+  _checkTokenState() async {
+    await _processTokenState(getToken());
+  }
+
+  Future<AccessTokenResponse?> _processTokenState(Future<AccessTokenResponse?> future) async {
+    try {
+      final token = await future;
+      if (token == null || !token.isValid() || token.isExpired()) {
+        _reset();
+      } else {
+        _updateTokenState(OAuthTokenState.valid);
+      }
+      return token;
+    } catch (e) {
+      _reset();
+      return null;
+    }
   }
 
   Future<void> _reset() async {
     await helper.removeAllTokens();
     _updateTokenState(OAuthTokenState.invalid);
-  }
-
-
-  AccessTokenResponse? _processTokenState(AccessTokenResponse? token) {
-    if (token == null || !token.isValid() || token.isExpired())  {
-      _reset();
-    } else {
-      _updateTokenState(OAuthTokenState.valid);
-    }
-    return token;
   }
 
   void _updateTokenState(OAuthTokenState newState) {

--- a/lib/core/presentation/widgets/bottom_bar_widget.dart
+++ b/lib/core/presentation/widgets/bottom_bar_widget.dart
@@ -1,5 +1,6 @@
 import 'package:app/core/application/auth/auth_bloc.dart';
 import 'package:app/core/presentation/widgets/lemon_circle_avatar_widget.dart';
+import 'package:app/core/presentation/widgets/loading_widget.dart';
 import 'package:app/gen/assets.gen.dart';
 import 'package:app/core/presentation/widgets/theme_svg_icon_widget.dart';
 import 'package:app/theme/spacing.dart';
@@ -66,6 +67,11 @@ class BottomBar extends StatelessWidget {
                   path: '/login',
                   icon: Icon(Icons.person, color: colorScheme.onPrimary, size: 24),
                 ),
+                processingChild: _buildItem(
+                  context,
+                  path: '',
+                  icon: Loading.defaultLoading(context),
+                ),
               ),
             ],
           )
@@ -74,7 +80,11 @@ class BottomBar extends StatelessWidget {
     );
   }
 
-  Widget _buildItem(BuildContext context, {required Widget icon, required String path}) {
+  Widget _buildItem(
+    BuildContext context, {
+    required Widget icon,
+    required String path,
+  }) {
     return Expanded(
       child: GestureDetector(
         behavior: HitTestBehavior.opaque,
@@ -92,9 +102,11 @@ class BottomBar extends StatelessWidget {
 class _ProfileAuthGuardItem extends StatelessWidget {
   final Widget authenticatedChild;
   final Widget unauthenticatedChild;
+  final Widget processingChild;
   const _ProfileAuthGuardItem({
     required this.authenticatedChild,
     required this.unauthenticatedChild,
+    required this.processingChild,
   });
 
   @override
@@ -107,7 +119,7 @@ class _ProfileAuthGuardItem extends StatelessWidget {
           },
           unauthenticated: (_) => unauthenticatedChild,
           unknown: () => unauthenticatedChild,
-          processing: () => unauthenticatedChild
+          processing: () => processingChild
         );
       },
     );

--- a/lib/core/service/auth/auth_service.dart
+++ b/lib/core/service/auth/auth_service.dart
@@ -13,10 +13,6 @@ class AuthService {
   final appOAuth = getIt<AppOauth>();
   Stream<OAuthTokenState> get tokenStateStream => appOAuth.tokenStateStream;
 
-  Future<void> close() async {
-    await appOAuth.dispose();
-  }
-
   Future<bool> checkAuthenticated() async {
     var res = await appOAuth.getTokenFromStorage();
     return res?.accessToken != null;

--- a/lib/core/service/auth/auth_service.dart
+++ b/lib/core/service/auth/auth_service.dart
@@ -6,22 +6,14 @@ import 'package:app/core/failure.dart';
 import 'package:app/core/oauth.dart';
 import 'package:app/injection/register_module.dart';
 import 'package:dartz/dartz.dart';
+import 'package:injectable/injectable.dart';
 
-typedef OnTokenChangeHandler = void Function(OAuthTokenState tokenState);
-
+@LazySingleton()
 class AuthService {
   final appOAuth = getIt<AppOauth>();
-  final OnTokenChangeHandler? onTokenStateChanged;
-  late final StreamSubscription<OAuthTokenState> tokenStateSubscription;
-
-  AuthService({this.onTokenStateChanged}) {
-    tokenStateSubscription = appOAuth.tokenStateStream.listen((tokenState) {
-      onTokenStateChanged?.call(tokenState);
-    });
-  }
+  Stream<OAuthTokenState> get tokenStateStream => appOAuth.tokenStateStream;
 
   Future<void> close() async {
-    await tokenStateSubscription.cancel();
     await appOAuth.dispose();
   }
 

--- a/lib/core/service/auth/auth_service.dart
+++ b/lib/core/service/auth/auth_service.dart
@@ -3,7 +3,7 @@ import 'dart:async';
 import 'package:app/core/domain/auth/entities/auth_session.dart';
 import 'package:app/core/domain/user/entities/user.dart';
 import 'package:app/core/failure.dart';
-import 'package:app/core/oauth.dart';
+import 'package:app/core/oauth/oauth.dart';
 import 'package:app/injection/register_module.dart';
 import 'package:dartz/dartz.dart';
 import 'package:injectable/injectable.dart';
@@ -12,11 +12,6 @@ import 'package:injectable/injectable.dart';
 class AuthService {
   final appOAuth = getIt<AppOauth>();
   Stream<OAuthTokenState> get tokenStateStream => appOAuth.tokenStateStream;
-
-  Future<bool> checkAuthenticated() async {
-    var res = await appOAuth.getTokenFromStorage();
-    return res?.accessToken != null;
-  }
 
   Future<Either<Failure, bool>> login() async {
     var res = await appOAuth.login();
@@ -30,8 +25,16 @@ class AuthService {
     );
   }
 
-  Future<bool> logout() async {
-    return await appOAuth.logout();
+  Future<Either<Failure, bool>> logout() async {
+    var res = await appOAuth.logout();
+    return res.fold(
+      (l) => Left(Failure()),
+      (success) {
+        if (success) return const Right(true);
+
+        return Left(Failure());
+      },
+    );
   }
 
   AuthSession createSession(AuthUser user) {

--- a/lib/core/service/shake/shake_service.dart
+++ b/lib/core/service/shake/shake_service.dart
@@ -1,6 +1,9 @@
 import 'package:app/core/config.dart';
+import 'package:app/core/oauth/oauth.dart';
 import 'package:app/core/service/firebase/firebase_service.dart';
+import 'package:app/injection/register_module.dart';
 import 'package:flutter/services.dart';
+import 'package:package_info_plus/package_info_plus.dart';
 import 'package:shake/shake.dart';
 import 'package:flutter/material.dart';
 
@@ -84,6 +87,23 @@ class ShakeService {
                         style: TextStyle(color: Colors.green),
                       ),
                     ),
+                  SizedBox(height: 16.0),
+                  FutureBuilder<PackageInfo>(
+                    future: PackageInfo.fromPlatform(),
+                    builder: (context, snapshot) {
+                      return Text('App version: ${snapshot.data?.version}\nBuild number: ${snapshot.data?.buildNumber}');
+                    }),
+                  SizedBox(height: 16.0),
+                  SizedBox(
+                    width: double.infinity,
+                    child: ElevatedButton(
+                      onPressed: () {
+                        getIt<AppOauth>().forceLogout();
+                        Navigator.pop(context);
+                      },
+                      child: Text("Force logout"),
+                    ),
+                  ),
                   SizedBox(height: 16.0),
                   Container(
                     // Use Container to set button width to full

--- a/lib/injection/register_module.config.dart
+++ b/lib/injection/register_module.config.dart
@@ -9,19 +9,20 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:app/core/application/auth/auth_bloc.dart' as _i14;
+import 'package:app/core/application/auth/auth_bloc.dart' as _i15;
 import 'package:app/core/data/event/repository/event_repository_impl.dart'
-    as _i6;
-import 'package:app/core/data/post/post_repository_impl.dart' as _i8;
-import 'package:app/core/data/token/token_repository_impl.dart' as _i10;
-import 'package:app/core/data/user/user_repository_impl.dart' as _i12;
-import 'package:app/core/domain/event/event_repository.dart' as _i5;
-import 'package:app/core/domain/post/post_repository.dart' as _i7;
-import 'package:app/core/domain/token/token_repository.dart' as _i9;
-import 'package:app/core/domain/user/user_repository.dart' as _i11;
+    as _i7;
+import 'package:app/core/data/post/post_repository_impl.dart' as _i9;
+import 'package:app/core/data/token/token_repository_impl.dart' as _i11;
+import 'package:app/core/data/user/user_repository_impl.dart' as _i13;
+import 'package:app/core/domain/event/event_repository.dart' as _i6;
+import 'package:app/core/domain/post/post_repository.dart' as _i8;
+import 'package:app/core/domain/token/token_repository.dart' as _i10;
+import 'package:app/core/domain/user/user_repository.dart' as _i12;
 import 'package:app/core/gql.dart' as _i3;
 import 'package:app/core/oauth.dart' as _i4;
-import 'package:app/core/service/user/user_service.dart' as _i13;
+import 'package:app/core/service/auth/auth_service.dart' as _i5;
+import 'package:app/core/service/user/user_service.dart' as _i14;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
 
@@ -38,14 +39,17 @@ extension GetItInjectableX on _i1.GetIt {
     );
     gh.lazySingleton<_i3.AppGQL>(() => _i3.AppGQL());
     gh.lazySingleton<_i4.AppOauth>(() => _i4.AppOauth());
-    gh.lazySingleton<_i5.EventRepository>(() => _i6.EventRepositoryImpl());
+    gh.lazySingleton<_i5.AuthService>(() => _i5.AuthService());
+    gh.lazySingleton<_i6.EventRepository>(() => _i7.EventRepositoryImpl());
     gh.lazySingleton<_i3.MetaverseGQL>(() => _i3.MetaverseGQL());
-    gh.lazySingleton<_i7.PostRepository>(() => _i8.PostRepositoryImpl());
-    gh.lazySingleton<_i9.TokenRepository>(() => _i10.TokenRepositoryImpl());
-    gh.lazySingleton<_i11.UserRepository>(() => _i12.UserRepositoryImpl());
-    gh.lazySingleton<_i13.UserService>(() => _i13.UserService());
-    gh.lazySingleton<_i14.AuthBloc>(
-        () => _i14.AuthBloc(userService: gh<_i13.UserService>()));
+    gh.lazySingleton<_i8.PostRepository>(() => _i9.PostRepositoryImpl());
+    gh.lazySingleton<_i10.TokenRepository>(() => _i11.TokenRepositoryImpl());
+    gh.lazySingleton<_i12.UserRepository>(() => _i13.UserRepositoryImpl());
+    gh.lazySingleton<_i14.UserService>(() => _i14.UserService());
+    gh.lazySingleton<_i15.AuthBloc>(() => _i15.AuthBloc(
+          userService: gh<_i14.UserService>(),
+          authService: gh<_i5.AuthService>(),
+        ));
     return this;
   }
 }

--- a/lib/injection/register_module.config.dart
+++ b/lib/injection/register_module.config.dart
@@ -20,7 +20,7 @@ import 'package:app/core/domain/post/post_repository.dart' as _i8;
 import 'package:app/core/domain/token/token_repository.dart' as _i10;
 import 'package:app/core/domain/user/user_repository.dart' as _i12;
 import 'package:app/core/gql.dart' as _i3;
-import 'package:app/core/oauth.dart' as _i4;
+import 'package:app/core/oauth/oauth.dart' as _i4;
 import 'package:app/core/service/auth/auth_service.dart' as _i5;
 import 'package:app/core/service/user/user_service.dart' as _i14;
 import 'package:get_it/get_it.dart' as _i1;

--- a/lib/main_development.dart
+++ b/lib/main_development.dart
@@ -1,4 +1,5 @@
 import 'package:app/app.dart';
+import 'package:app/core/oauth/oauth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:graphql_flutter/graphql_flutter.dart' as gql_flutter;
@@ -10,6 +11,8 @@ void main() async {
   await gql_flutter.initHiveForFlutter();
   
   registerModule();
+
+  await getIt<AppOauth>().init();
 
   runApp(LemonadeApp());
 

--- a/lib/main_production.dart
+++ b/lib/main_production.dart
@@ -1,4 +1,5 @@
 import 'package:app/app.dart';
+import 'package:app/core/oauth/oauth.dart';
 import 'package:app/core/service/firebase/firebase_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -13,10 +14,11 @@ void main() async {
   final firebaseService = FirebaseService();
   await firebaseService.initialize();
   final token = await firebaseService.getToken();
-  
   debugPrint('FCM Token: $token');
   
   registerModule();
+  
+  await getIt<AppOauth>().init();
 
   runApp(LemonadeApp());
 

--- a/lib/main_staging.dart
+++ b/lib/main_staging.dart
@@ -1,4 +1,5 @@
 import 'package:app/app.dart';
+import 'package:app/core/oauth/oauth.dart';
 import 'package:app/core/service/firebase/firebase_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
@@ -9,7 +10,7 @@ void main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: '.env.staging');
   await gql_flutter.initHiveForFlutter();
-  
+
   final firebaseService = FirebaseService();
   await firebaseService.initialize();
   final token = await firebaseService.getToken();
@@ -17,6 +18,8 @@ void main() async {
   debugPrint('FCM Token: $token');
   
   registerModule();
+
+  await getIt<AppOauth>().init();
 
   runApp(LemonadeApp());
 

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -13,6 +13,7 @@ import flutter_appauth
 import flutter_secure_storage_macos
 import flutter_web_auth_2
 import geolocator_apple
+import package_info_plus
 import path_provider_foundation
 import share_plus
 import sqflite
@@ -28,6 +29,7 @@ func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   FlutterWebAuth2Plugin.register(with: registry.registrar(forPlugin: "FlutterWebAuth2Plugin"))
   GeolocatorPlugin.register(with: registry.registrar(forPlugin: "GeolocatorPlugin"))
+  FLTPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FLTPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))
   SqflitePlugin.register(with: registry.registrar(forPlugin: "SqflitePlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -585,7 +585,7 @@ packages:
     source: sdk
     version: "0.0.0"
   flutter_web_auth_2:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: flutter_web_auth_2
       sha256: ee636fa43af689df8ace6421ea5f5e14b8b3eda0e8caa3e5a1e3bb71f0833636
@@ -981,6 +981,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
+  package_info_plus:
+    dependency: "direct main"
+    description:
+      name: package_info_plus
+      sha256: ceb027f6bc6a60674a233b4a90a7658af1aebdea833da0b5b53c1e9821a78c7b
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.2"
+  package_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: package_info_plus_platform_interface
+      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.1"
   path:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1142,7 +1142,7 @@ packages:
     source: hosted
     version: "4.1.0"
   rxdart:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: rxdart
       sha256: "0c7c0cedd93788d996e33041ffecda924cc54389199cde4e6a34b440f50044cb"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   
   # location tracking
   geolocator: 9.0.2
+  rxdart: ^0.27.7
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -40,12 +40,12 @@ dependencies:
   share_plus: ^7.0.2
   shake: ^2.2.0
   flutter_native_splash: ^2.3.1
+  package_info_plus: ^4.0.2
 
   # navigation
   auto_route: ^7.4.0
 
   # oauth
-  flutter_web_auth_2: ^2.1.4
   oauth2_client: ^3.2.1
   flutter_appauth: ^5.0.0
 


### PR DESCRIPTION
# What ? 
- Replace stream controller in AppOAuth by using BehaviorSubject 

# Why ? 
BehaviorSubject is designed to emit the last event dispatched to its listeners. This ensures any newly subscribed listener receives the current state of the stream event.
The need for this change arises in the tokenStateSubscription within AuthBloc. Currently, this subscription initializes after the tokenStream has already dispatched an event. Switching to BehaviorSubject will guarantee that AuthBloc correctly shows the updated state, despite the dispatch occurring prior to the subscription initialization. This implementation provides an accurate reflection of the current token state.

# How ?
- Add rxdart package which include BehaviorSubject