### PR TITLE
fix(newsfeed): move refreshController back to UI

### DIFF
--- a/lib/core/application/newsfeed/newsfeed_listing_bloc/newsfeed_listing_bloc.dart
+++ b/lib/core/application/newsfeed/newsfeed_listing_bloc/newsfeed_listing_bloc.dart
@@ -7,7 +7,6 @@ import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
-import 'package:pull_to_refresh_flutter3/pull_to_refresh_flutter3.dart';
 
 part 'newsfeed_listing_bloc.freezed.dart';
 
@@ -27,7 +26,6 @@ class NewsfeedListingBloc
     getDataFuture: _getNewsfeed,
   );
   final defaultInput = const GetNewsfeedInput();
-  final refreshController = RefreshController();
   final scrollController = ScrollController();
 
   Future<Either<Failure, List<Post>>> _getNewsfeed(
@@ -94,7 +92,6 @@ class NewsfeedListingBloc
 
   @override
   Future<void> close() {
-    refreshController.dispose();
     scrollController.dispose();
     return super.close();
   }

--- a/lib/core/presentation/pages/home/views/list/home_newsfeed_list.dart
+++ b/lib/core/presentation/pages/home/views/list/home_newsfeed_list.dart
@@ -17,6 +17,8 @@ class HomeNewsfeedListView extends StatelessWidget {
     final t = Translations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
     final bloc = context.read<NewsfeedListingBloc>();
+    final refreshController = RefreshController();
+
     return BlocConsumer<NewsfeedListingBloc, NewsfeedListingState>(
       listener: (context, state) {
         if (state.scrollToTopEvent) {
@@ -46,20 +48,20 @@ class HomeNewsfeedListView extends StatelessWidget {
           );
         }
         return SmartRefresher(
-          controller: bloc.refreshController,
+          controller: refreshController,
           enablePullUp: true,
           onRefresh: () {
             context
                 .read<NewsfeedListingBloc>()
                 .add(NewsfeedListingEvent.fetch());
-            bloc.refreshController.refreshCompleted();
+            refreshController.refreshCompleted();
           },
           onLoading: () {
             // add load more here
             context
                 .read<NewsfeedListingBloc>()
                 .add(NewsfeedListingEvent.fetch());
-            bloc.refreshController.loadComplete();
+            refreshController.loadComplete();
           },
           footer: const ClassicFooter(
             height: 100,


### PR DESCRIPTION
## Overview 
- Fix error RefreshController was use multiple times

![image](https://github.com/lemonadesocial/lemonade-flutter/assets/108661349/533da4a1-3d9f-434a-bf55-87776606dd5f)
