### PR TITLE
fix(newsfeed): add initial loading indicator

### DIFF
--- a/lib/core/presentation/pages/home/views/list/home_newsfeed_list.dart
+++ b/lib/core/presentation/pages/home/views/list/home_newsfeed_list.dart
@@ -1,5 +1,6 @@
 import 'package:app/core/application/newsfeed/newsfeed_listing_bloc/newsfeed_listing_bloc.dart';
 import 'package:app/core/presentation/widgets/common/list/empty_list_widget.dart';
+import 'package:app/core/presentation/widgets/loading_widget.dart';
 import 'package:app/core/presentation/widgets/post/post_profile_card_widget.dart';
 import 'package:app/i18n/i18n.g.dart';
 import 'package:app/theme/spacing.dart';
@@ -38,9 +39,13 @@ class HomeNewsfeedListView extends StatelessWidget {
       },
       builder: (context, state) {
         if (state.posts.isEmpty) {
-          return Center(
-            child: EmptyList(emptyText: t.notification.emptyNotifications),
-          );
+          if (state.status != NewsfeedStatus.fetched) {
+            return Loading.defaultLoading(context);
+          } else {
+            return Center(
+              child: EmptyList(emptyText: t.notification.emptyNotifications),
+            );
+          }
         }
         if (state.status == NewsfeedStatus.failure) {
           return Center(


### PR DESCRIPTION
## Overview
- Fix this Trello issue: https://trello.com/c/mYZgErSJ/218-show-loading-when-fetching-newsfeed-instead-of-show-empty-data-first

## Screenshot
![Simulator Screenshot - iPhone 14 Pro Max - 2023-09-11 at 11 24 14](https://github.com/lemonadesocial/lemonade-flutter/assets/108661349/9fcc1d57-004a-4620-a767-6a603465421f)
