### PR TITLE
fix(image exception): add bypass method on image error

### DIFF
--- a/lib/core/service/firebase/firebase_service.dart
+++ b/lib/core/service/firebase/firebase_service.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:app/core/config.dart';
 import 'package:app/core/data/fcm/fcm_mutation.dart';
@@ -100,6 +101,16 @@ class FirebaseService {
       FirebaseCrashlytics.instance
           .setCrashlyticsCollectionEnabled(kDebugMode == false);
       FlutterError.onError = (errorDetails) {
+        /// Bypass [ArgumentError]
+        if (errorDetails.exception is ArgumentError) return;
+        if (errorDetails.exception is HttpException) {
+          final error = errorDetails.exception as HttpException;
+          final statusCode =
+              int.parse(error.message.substring(error.message.length - 3));
+
+          /// Bypass statusCode 404
+          if (statusCode == 404) return;
+        }
         // If you wish to record a "non-fatal" exception, please use `FirebaseCrashlytics.instance.recordFlutterError` instead
         FirebaseCrashlytics.instance.recordFlutterFatalError(errorDetails);
       };


### PR DESCRIPTION
## Overview:
- Add bypass method on 2 errors:

1. [_HttpClient.openUrl](https://console.firebase.google.com/u/1/project/lemonade-staging-88d1c/crashlytics/app/android:social.lemonade.app.staging/issues/d765c8a306f83792053e63e3e30ab020?time=last-seven-days&types=crash)
2. [FirebaseService.initialize.<fn>](https://console.firebase.google.com/u/1/project/lemonade-staging-88d1c/crashlytics/app/android:social.lemonade.app.staging/issues/610d5d564c4c564fd4ffc2ba459c4746?time=last-seven-days&types=crash)