### PR TITLE
fix: image 413 error

### DIFF
--- a/lib/core/presentation/pages/edit_profile/widgets/edit_profile_avatar.dart
+++ b/lib/core/presentation/pages/edit_profile/widgets/edit_profile_avatar.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 
 import 'package:app/core/application/profile/edit_profile_bloc/edit_profile_bloc.dart';
+import 'package:app/core/presentation/widgets/image_placeholder_widget.dart';
 import 'package:app/core/presentation/widgets/theme_svg_icon_widget.dart';
 import 'package:app/gen/assets.gen.dart';
 import 'package:app/theme/color.dart';
@@ -39,7 +40,13 @@ class EditProfileAvatar extends StatelessWidget {
                             File(imageFile!.path),
                             fit: BoxFit.fill,
                           )
-                        : CachedNetworkImage(imageUrl: imageUrl!),
+                        : CachedNetworkImage(
+                            imageUrl: imageUrl!,
+                            placeholder: (_, __) =>
+                                ImagePlaceholder.defaultPlaceholder(),
+                            errorWidget: (_, __, ___) =>
+                                ImagePlaceholder.defaultPlaceholder(),
+                          ),
                   ),
                 ),
                 Positioned(

--- a/lib/core/presentation/pages/event/guest_event_detail_page/widgets/guest_event_location.dart
+++ b/lib/core/presentation/pages/event/guest_event_detail_page/widgets/guest_event_location.dart
@@ -1,6 +1,7 @@
 import 'package:app/core/application/auth/auth_bloc.dart';
 import 'package:app/core/domain/event/entities/event.dart';
 import 'package:app/core/presentation/pages/event/guest_event_detail_page/widgets/ripple_marker.dart';
+import 'package:app/core/presentation/widgets/image_placeholder_widget.dart';
 import 'package:app/core/utils/map_utils.dart';
 import 'package:app/gen/assets.gen.dart';
 import 'package:app/gen/fonts.gen.dart';
@@ -56,6 +57,9 @@ class GuestEventLocation extends StatelessWidget {
                     Positioned.fill(
                       child: CachedNetworkImage(
                         fit: BoxFit.cover,
+                        placeholder: (_, __) => ImagePlaceholder.eventCard(),
+                        errorWidget: (_, __, ___) =>
+                            ImagePlaceholder.eventCard(),
                         imageUrl: MapUtils.createGoogleMapsURL(
                           lat: event.latitude ?? 0,
                           lng: event.longitude ?? 0,

--- a/lib/core/presentation/pages/event/guest_event_detail_page/widgets/guest_event_poap_offer_item.dart
+++ b/lib/core/presentation/pages/event/guest_event_detail_page/widgets/guest_event_poap_offer_item.dart
@@ -107,6 +107,10 @@ class GuestEventPoapOfferItemState extends State<GuestEventPoapOfferItemView>
                       child: CachedNetworkImage(
                         fit: BoxFit.cover,
                         imageUrl: snapshot.data?.url ?? '',
+                        placeholder: (_, __) =>
+                            ImagePlaceholder.defaultPlaceholder(),
+                        errorWidget: (_, __, ___) =>
+                            ImagePlaceholder.defaultPlaceholder(),
                       ),
                     ),
                   ),

--- a/lib/core/presentation/pages/profile/views/tabs/profile_event_tab_view.dart
+++ b/lib/core/presentation/pages/profile/views/tabs/profile_event_tab_view.dart
@@ -262,7 +262,9 @@ class _EventItem extends StatelessWidget {
                           imageConfig: ImageConfig.eventPhoto,
                         ),
                         fit: BoxFit.cover,
-                        errorWidget: (ctx, _, __) =>
+                        placeholder: (_, __) =>
+                            ImagePlaceholder.defaultPlaceholder(),
+                        errorWidget: (_, __, ___) =>
                             ImagePlaceholder.defaultPlaceholder(),
                       ),
                     )

--- a/lib/core/presentation/widgets/common/photos_gallery_page/photos_gallery_page.dart
+++ b/lib/core/presentation/widgets/common/photos_gallery_page/photos_gallery_page.dart
@@ -148,6 +148,10 @@ class _PhotosGalleryPageState extends State<PhotosGalleryPage> {
                               width: 42.w,
                               height: 42.w,
                               fit: BoxFit.cover,
+                              placeholder: (_, __) =>
+                                  ImagePlaceholder.defaultPlaceholder(),
+                              errorWidget: (_, __, ___) =>
+                                  ImagePlaceholder.defaultPlaceholder(),
                             ),
                           ),
                         ),

--- a/lib/core/service/firebase/firebase_service.dart
+++ b/lib/core/service/firebase/firebase_service.dart
@@ -99,9 +99,18 @@ class FirebaseService {
       );
       FirebaseCrashlytics.instance
           .setCrashlyticsCollectionEnabled(kDebugMode == false);
-      FlutterError.onError = (errorDetails) {
-        // If you wish to record a "non-fatal" exception, please use `FirebaseCrashlytics.instance.recordFlutterError` instead
-        FirebaseCrashlytics.instance.recordFlutterFatalError(errorDetails);
+      FlutterError.onError = (flutterErrorDetails) async {
+        // Prevent flush crash analytics error
+        // https://github.com/Baseflow/flutter_cached_network_image/issues/336
+        if (flutterErrorDetails.library == "image resource service" &&
+            flutterErrorDetails.exception
+                .toString()
+                .startsWith("HttpException: Invalid statusCode: 413, uri")) {
+          return;
+        }
+        await FirebaseCrashlytics.instance
+            .recordFlutterFatalError(flutterErrorDetails);
+        return;
       };
       PlatformDispatcher.instance.onError = (error, stack) {
         // If you wish to record a "non-fatal" exception, please remove the "fatal" parameter


### PR DESCRIPTION
## Overview

- Fix these 413 image error causing flushing Firebase crash analytics report

<img width="1252" alt="Screenshot 2023-11-15 at 10 55 36" src="https://github.com/lemonadesocial/lemonade-flutter/assets/7247063/3d47277d-70e9-478b-942d-e2983383157a">
