### PR TITLE
fix: collapsedHeight should be equal tool bar height

### DIFF
--- a/lib/core/presentation/pages/event/guest_event_detail_page/widgets/guest_event_detail_appbar.dart
+++ b/lib/core/presentation/pages/event/guest_event_detail_page/widgets/guest_event_detail_appbar.dart
@@ -28,7 +28,7 @@ class GuestEventDetailAppBar extends StatelessWidget {
       stretch: true,
       floating: true,
       leading: const SizedBox.shrink(),
-      collapsedHeight: 60.h,
+      collapsedHeight: kToolbarHeight,
       expandedHeight: isIpad ? 280.h : 188.h,
       centerTitle: true,
       title: AnimatedOpacity(


### PR DESCRIPTION
# What ?
- Fix error when collapsedHeight is lower than kToolbarHeight then flutter sdk throw error 