### PR TITLE
fix: update placeholder text for create post screen

### DIFF
--- a/lib/core/presentation/pages/create_post/create_post_page.dart
+++ b/lib/core/presentation/pages/create_post/create_post_page.dart
@@ -1,5 +1,7 @@
+import 'package:app/core/application/auth/auth_bloc.dart';
 import 'package:app/core/application/newsfeed/newsfeed_listing_bloc/newsfeed_listing_bloc.dart';
 import 'package:app/core/application/post/create_post_bloc/create_post_bloc.dart';
+import 'package:app/core/domain/user/entities/user.dart';
 import 'package:app/core/presentation/pages/create_post/widgets/create_post_event_card_widget.dart';
 import 'package:app/core/presentation/pages/event/event_selecting_page.dart';
 import 'package:app/core/presentation/widgets/back_button_widget.dart';
@@ -32,6 +34,10 @@ class CreatePostPage extends StatelessWidget {
     final t = Translations.of(context);
     final colorScheme = Theme.of(context).colorScheme;
     final createPostBloc = CreatePostBloc(PostService(getIt<PostRepository>()));
+    User? user = context.watch<AuthBloc>().state.maybeWhen(
+          authenticated: (authSession) => authSession,
+          orElse: () => null,
+        );
 
     return BlocProvider<CreatePostBloc>(
       create: (context) => createPostBloc,
@@ -123,7 +129,9 @@ class CreatePostPage extends StatelessWidget {
                               onChanged: createPostBloc.onPostDescriptionChange,
                               cursorColor: colorScheme.onPrimary,
                               decoration: InputDecoration.collapsed(
-                                hintText: t.home.whatOnYourMind,
+                                hintText: user?.displayName != null
+                                    ? '${t.home.whatOnYourMind}, ${user!.displayName} ?'
+                                    : t.home.whatOnYourMind,
                               ),
                               style: Typo.medium.copyWith(
                                 fontSize: 16,

--- a/lib/i18n/home/home_en.i18n.json
+++ b/lib/i18n/home/home_en.i18n.json
@@ -1,6 +1,6 @@
 {
     "newsfeed": "Newsfeed",
-    "whatOnYourMind": "What's on your mind, Joseph?",
+    "whatOnYourMind": "What's on your mind",
     "create": "Create",
     "comingSoon": "Coming soon",
     "post": "Post",


### PR DESCRIPTION
## Overview

- Related bug issue : https://trello.com/c/SVCS9zgV/340-creating-new-post-should-show-current-name-instead-of-joseph

## Demo

<img width="398" alt="Screenshot 2024-01-26 at 09 53 52" src="https://github.com/lemonadesocial/lemonade-flutter/assets/7247063/7526c6dc-c144-405a-911a-c5c0dbc795d1">
