### PR TITLE
fix: support navigate to create event page in ai-chat

### DIFF
--- a/lib/core/presentation/pages/ai/widgets/ai_chat_command_view.dart
+++ b/lib/core/presentation/pages/ai/widgets/ai_chat_command_view.dart
@@ -173,7 +173,7 @@ class Header extends StatelessWidget {
                   t.ai.chattingWith,
                   style: Typo.small.copyWith(color: colorScheme.onSecondary),
                 ),
-                SizedBox(height: 2.h),
+                SizedBox(height: 1.h),
                 Row(
                   children: [
                     Text(

--- a/lib/core/presentation/widgets/ai/ai_chat_card.dart
+++ b/lib/core/presentation/widgets/ai/ai_chat_card.dart
@@ -147,6 +147,9 @@ class AIChatCard extends StatelessWidget {
         if (targetObject.action == AIMetadataAction.createPost) {
           Vibrate.feedback(FeedbackType.light);
           AutoRouter.of(context).navigate(const CreatePostRoute());
+        } else if (targetObject.action == AIMetadataAction.createEvent) {
+          Vibrate.feedback(FeedbackType.light);
+          AutoRouter.of(context).navigate(const CreateEventRoute());
         }
       },
     );


### PR DESCRIPTION
## Issue

https://trello.com/c/wwxmztlz/344-ai-chat-enter-command-create-event-cannot-click-to-create-new-event