### PR TITLE
fix: cta button layout

### DIFF
--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/event_cohosts_setting_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/event_cohosts_setting_page.dart
@@ -73,10 +73,10 @@ class _EventCohostsSettingPageViewState
             );
     return Scaffold(
       appBar: LemonAppBar(
-        backgroundColor: colorScheme.onPrimaryContainer,
+        backgroundColor: colorScheme.background,
         title: t.event.configuration.coHosts,
       ),
-      backgroundColor: colorScheme.onPrimaryContainer,
+      backgroundColor: colorScheme.background,
       resizeToAvoidBottomInset: true,
       body: BlocListener<ManageEventCohostRequestsBloc,
           ManageEventCohostRequestsState>(

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/event_cohosts_setting_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/event_cohosts_setting_page.dart
@@ -127,16 +127,21 @@ class _EventCohostsSettingPageViewState
   Widget _buildAddCohostsButton() {
     return BlocBuilder<EditEventDetailBloc, EditEventDetailState>(
       builder: (context, state) {
-        return LinearGradientButton(
-          label: t.event.cohosts.addCohosts,
-          height: 48.h,
-          radius: BorderRadius.circular(24),
-          textStyle: Typo.medium.copyWith(),
-          mode: GradientButtonMode.lavenderMode,
-          onTap: () {
-            AutoRouter.of(context).navigate(const EventAddCohostsRoute());
-          },
-          loadingWhen: state.status == EditEventDetailBlocStatus.loading,
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: SafeArea(
+            child: LinearGradientButton(
+              label: t.event.cohosts.addCohosts,
+              height: 48.h,
+              radius: BorderRadius.circular(24),
+              textStyle: Typo.medium.copyWith(),
+              mode: GradientButtonMode.lavenderMode,
+              onTap: () {
+                AutoRouter.of(context).navigate(const EventAddCohostsRoute());
+              },
+              loadingWhen: state.status == EditEventDetailBlocStatus.loading,
+            ),
+          ),
         );
       },
     );

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/event_cohosts_setting_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/event_cohosts_setting_page.dart
@@ -7,6 +7,7 @@ import 'package:app/core/domain/event/entities/event_cohost_request.dart';
 import 'package:app/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/widgets/event_cohost_item.dart';
 import 'package:app/core/presentation/widgets/common/appbar/lemon_appbar_widget.dart';
 import 'package:app/core/presentation/widgets/common/button/linear_gradient_button_widget.dart';
+import 'package:app/core/presentation/widgets/common/list/empty_list_widget.dart';
 import 'package:app/core/presentation/widgets/loading_widget.dart';
 import 'package:app/i18n/i18n.g.dart';
 import 'package:app/router/app_router.gr.dart';
@@ -111,10 +112,12 @@ class _EventCohostsSettingPageViewState
                 child: loadingEventCohostsRequests ||
                         loadingManageEventCohostRequests
                     ? Loading.defaultLoading(context)
-                    : CohostsList(
-                        eventCohostsRequests: eventCohostsRequests,
-                        event: widget.event,
-                      ),
+                    : eventCohostsRequests.isEmpty
+                        ? const EmptyList()
+                        : CohostsList(
+                            eventCohostsRequests: eventCohostsRequests,
+                            event: widget.event,
+                          ),
               ),
               _buildAddCohostsButton(),
             ],

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/sub_pages/event_add_cohosts_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/sub_pages/event_add_cohosts_page.dart
@@ -169,24 +169,29 @@ class _EventAddCohostsViewState extends State<EventAddCohostsView> {
           loading: () => true,
           orElse: () => false,
         );
-        return LinearGradientButton(
-          label: t.common.actions.saveChanges,
-          height: 48.h,
-          radius: BorderRadius.circular(24),
-          textStyle: Typo.medium.copyWith(),
-          mode: GradientButtonMode.lavenderMode,
-          onTap: () {
-            FocusScope.of(context).requestFocus(FocusNode());
-            Vibrate.feedback(FeedbackType.light);
-            context.read<ManageEventCohostRequestsBloc>().add(
-                  ManageEventCohostRequestsEvent.saveChanged(
-                    eventId: widget.event?.id ?? '',
-                    users: selectedUserIds,
-                    decision: true,
-                  ),
-                );
-          },
-          loadingWhen: loading,
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: SafeArea(
+            child: LinearGradientButton(
+              label: t.common.actions.saveChanges,
+              height: 48.h,
+              radius: BorderRadius.circular(24),
+              textStyle: Typo.medium.copyWith(),
+              mode: GradientButtonMode.lavenderMode,
+              onTap: () {
+                FocusScope.of(context).requestFocus(FocusNode());
+                Vibrate.feedback(FeedbackType.light);
+                context.read<ManageEventCohostRequestsBloc>().add(
+                      ManageEventCohostRequestsEvent.saveChanged(
+                        eventId: widget.event?.id ?? '',
+                        users: selectedUserIds,
+                        decision: true,
+                      ),
+                    );
+              },
+              loadingWhen: loading,
+            ),
+          ),
         );
       },
     );

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/sub_pages/event_add_cohosts_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_cohosts_setting_page/sub_pages/event_add_cohosts_page.dart
@@ -56,10 +56,10 @@ class _EventAddCohostsViewState extends State<EventAddCohostsView> {
     final t = Translations.of(context);
     return Scaffold(
       appBar: LemonAppBar(
-        backgroundColor: colorScheme.onPrimaryContainer,
+        backgroundColor: colorScheme.background,
         title: t.event.cohosts.addCohosts,
       ),
-      backgroundColor: colorScheme.onPrimaryContainer,
+      backgroundColor: colorScheme.background,
       resizeToAvoidBottomInset: true,
       body: BlocListener<ManageEventCohostRequestsBloc,
           ManageEventCohostRequestsState>(

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_location_setting_page/event_location_setting_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_location_setting_page/event_location_setting_page.dart
@@ -143,28 +143,33 @@ class _EventLocationSettingPageState extends State<EventLocationSettingPage> {
   _buildSaveButton() {
     return BlocBuilder<EditEventDetailBloc, EditEventDetailState>(
       builder: (context, state) {
-        return LinearGradientButton(
-          label: t.common.actions.save,
-          height: 48.h,
-          radius: BorderRadius.circular(24),
-          textStyle: Typo.medium.copyWith(),
-          mode: GradientButtonMode.lavenderMode,
-          onTap: () {
-            if (widget.event != null) {
-              context.read<EditEventDetailBloc>().add(
-                    EditEventDetailEvent.update(
-                      eventId: widget.event?.id ?? '',
-                      address: context
-                          .read<EventLocationSettingBloc>()
-                          .state
-                          .selectedAddress,
-                    ),
-                  );
-            } else {
-              AutoRouter.of(context).pop();
-            }
-          },
-          loadingWhen: state.status == EditEventDetailBlocStatus.loading,
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: SafeArea(
+            child: LinearGradientButton(
+              label: t.common.actions.save,
+              height: 48.h,
+              radius: BorderRadius.circular(24),
+              textStyle: Typo.medium.copyWith(),
+              mode: GradientButtonMode.lavenderMode,
+              onTap: () {
+                if (widget.event != null) {
+                  context.read<EditEventDetailBloc>().add(
+                        EditEventDetailEvent.update(
+                          eventId: widget.event?.id ?? '',
+                          address: context
+                              .read<EventLocationSettingBloc>()
+                              .state
+                              .selectedAddress,
+                        ),
+                      );
+                } else {
+                  AutoRouter.of(context).pop();
+                }
+              },
+              loadingWhen: state.status == EditEventDetailBlocStatus.loading,
+            ),
+          ),
         );
       },
     );

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_reward_setting_page/sub_pages/event_rewards_listing_page/event_rewards_listing_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_reward_setting_page/sub_pages/event_rewards_listing_page/event_rewards_listing_page.dart
@@ -40,10 +40,8 @@ class EventRewardsListingPage extends StatelessWidget {
               physics: const BouncingScrollPhysics(),
               slivers: [
                 if (rewards.isEmpty)
-                  SliverToBoxAdapter(
-                    child: Center(
-                      child: EmptyList(emptyText: t.event.noRewards),
-                    ),
+                  const SliverToBoxAdapter(
+                    child: EmptyList(),
                   ),
                 if (rewards.isNotEmpty)
                   SliverList.separated(

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/event_speakers_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/event_speakers_page.dart
@@ -109,15 +109,20 @@ class _EventSpeakersPageViewState extends State<EventSpeakersPageView> {
   }
 
   _buildAddSpeakersButton() {
-    return LinearGradientButton(
-      label: t.event.speakers.addSpeakers,
-      height: 48.h,
-      radius: BorderRadius.circular(24),
-      textStyle: Typo.medium.copyWith(),
-      mode: GradientButtonMode.lavenderMode,
-      onTap: () {
-        AutoRouter.of(context).navigate(const EventAddSpeakersRoute());
-      },
+    return Align(
+      alignment: Alignment.bottomCenter,
+      child: SafeArea(
+        child: LinearGradientButton(
+          label: t.event.speakers.addSpeakers,
+          height: 48.h,
+          radius: BorderRadius.circular(24),
+          textStyle: Typo.medium.copyWith(),
+          mode: GradientButtonMode.lavenderMode,
+          onTap: () {
+            AutoRouter.of(context).navigate(const EventAddSpeakersRoute());
+          },
+        ),
+      ),
     );
   }
 }

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/event_speakers_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/event_speakers_page.dart
@@ -5,6 +5,7 @@ import 'package:app/core/domain/user/entities/user.dart';
 import 'package:app/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/widgets/event_speaker_item.dart';
 import 'package:app/core/presentation/widgets/common/appbar/lemon_appbar_widget.dart';
 import 'package:app/core/presentation/widgets/common/button/linear_gradient_button_widget.dart';
+import 'package:app/core/presentation/widgets/common/list/empty_list_widget.dart';
 import 'package:app/core/presentation/widgets/loading_widget.dart';
 import 'package:app/i18n/i18n.g.dart';
 import 'package:app/router/app_router.gr.dart';
@@ -96,10 +97,12 @@ class _EventSpeakersPageViewState extends State<EventSpeakersPageView> {
             Expanded(
               child: loadingEditEventDetail || loadingGetEventDetail
                   ? Loading.defaultLoading(context)
-                  : SpeakersList(
-                      users: speakerUsers,
-                      event: widget.event,
-                    ),
+                  : speakerUsers.isEmpty
+                      ? const EmptyList()
+                      : SpeakersList(
+                          users: speakerUsers,
+                          event: widget.event,
+                        ),
             ),
             _buildAddSpeakersButton(),
           ],

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/event_speakers_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/event_speakers_page.dart
@@ -50,10 +50,10 @@ class _EventSpeakersPageViewState extends State<EventSpeakersPageView> {
     final t = Translations.of(context);
     return Scaffold(
       appBar: LemonAppBar(
-        backgroundColor: colorScheme.onPrimaryContainer,
+        backgroundColor: colorScheme.background,
         title: t.event.configuration.speakers,
       ),
-      backgroundColor: colorScheme.onPrimaryContainer,
+      backgroundColor: colorScheme.background,
       resizeToAvoidBottomInset: true,
       body: _buildContent(),
     );

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/sub_pages/event_add_speakers_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/sub_pages/event_add_speakers_page.dart
@@ -157,34 +157,39 @@ class _EventAddSpeakersViewState extends State<EventAddSpeakersView> {
   _buildAddSpeakersButton() {
     return BlocBuilder<EditEventDetailBloc, EditEventDetailState>(
       builder: (context, state) {
-        return LinearGradientButton(
-          label: t.common.actions.saveChanges,
-          height: 48.h,
-          radius: BorderRadius.circular(24),
-          textStyle: Typo.medium.copyWith(),
-          mode: GradientButtonMode.lavenderMode,
-          onTap: () {
-            FocusScope.of(context).requestFocus(FocusNode());
-            List<User?> speakerUsers =
-                context.read<GetEventDetailBloc>().state.maybeWhen(
-                      fetched: (eventDetail) =>
-                          eventDetail.speakerUsersExpanded ?? [],
-                      orElse: () => [],
+        return Align(
+          alignment: Alignment.bottomCenter,
+          child: SafeArea(
+            child: LinearGradientButton(
+              label: t.common.actions.saveChanges,
+              height: 48.h,
+              radius: BorderRadius.circular(24),
+              textStyle: Typo.medium.copyWith(),
+              mode: GradientButtonMode.lavenderMode,
+              onTap: () {
+                FocusScope.of(context).requestFocus(FocusNode());
+                List<User?> speakerUsers =
+                    context.read<GetEventDetailBloc>().state.maybeWhen(
+                          fetched: (eventDetail) =>
+                              eventDetail.speakerUsersExpanded ?? [],
+                          orElse: () => [],
+                        );
+                List<String> speakerUsersIds =
+                    speakerUsers.map((user) => user!.userId).toList();
+                // Included old speakers and with new selected speakers
+                List<String> newSpeakerUsers =
+                    (speakerUsersIds + selectedUserIds).toSet().toList();
+                Vibrate.feedback(FeedbackType.light);
+                context.read<EditEventDetailBloc>().add(
+                      EditEventDetailEvent.update(
+                        eventId: widget.event?.id ?? '',
+                        speakerUsers: newSpeakerUsers,
+                      ),
                     );
-            List<String> speakerUsersIds =
-                speakerUsers.map((user) => user!.userId).toList();
-            // Included old speakers and with new selected speakers
-            List<String> newSpeakerUsers =
-                (speakerUsersIds + selectedUserIds).toSet().toList();
-            Vibrate.feedback(FeedbackType.light);
-            context.read<EditEventDetailBloc>().add(
-                  EditEventDetailEvent.update(
-                    eventId: widget.event?.id ?? '',
-                    speakerUsers: newSpeakerUsers,
-                  ),
-                );
-          },
-          loadingWhen: state.status == EditEventDetailBlocStatus.loading,
+              },
+              loadingWhen: state.status == EditEventDetailBlocStatus.loading,
+            ),
+          ),
         );
       },
     );

--- a/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/sub_pages/event_add_speakers_page.dart
+++ b/lib/core/presentation/pages/event/event_control_panel_page/sub_pages/event_speakers_page/sub_pages/event_add_speakers_page.dart
@@ -55,10 +55,10 @@ class _EventAddSpeakersViewState extends State<EventAddSpeakersView> {
     final t = Translations.of(context);
     return Scaffold(
       appBar: LemonAppBar(
-        backgroundColor: colorScheme.onPrimaryContainer,
+        backgroundColor: colorScheme.background,
         title: t.event.speakers.addSpeakers,
       ),
-      backgroundColor: colorScheme.onPrimaryContainer,
+      backgroundColor: colorScheme.background,
       resizeToAvoidBottomInset: true,
       body: BlocListener<EditEventDetailBloc, EditEventDetailState>(
         listener: (context, state) {

--- a/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/view/host_event_detail_view.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/view/host_event_detail_view.dart
@@ -114,6 +114,9 @@ class HostEventDetailView extends StatelessWidget {
                       ),
                     ),
                   ],
+                  SliverPadding(
+                    padding: EdgeInsets.symmetric(vertical: Spacing.medium),
+                  ),
                 ],
               ),
             );

--- a/lib/core/presentation/widgets/common/list/empty_list_widget.dart
+++ b/lib/core/presentation/widgets/common/list/empty_list_widget.dart
@@ -1,4 +1,5 @@
 import 'package:app/gen/assets.gen.dart';
+import 'package:app/i18n/i18n.g.dart';
 import 'package:app/theme/spacing.dart';
 import 'package:app/theme/typo.dart';
 import 'package:flutter/material.dart';
@@ -15,17 +16,15 @@ class EmptyList extends StatelessWidget {
     final colorScheme = Theme.of(context).colorScheme;
     return Center(
       child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
+        mainAxisAlignment: MainAxisAlignment.start,
         children: [
           Assets.icons.icEmptyList.svg(),
-          if (emptyText != null) ...[
-            SizedBox(height: Spacing.smMedium),
-            Text(
-              emptyText!,
-              style: Typo.small.copyWith(color: colorScheme.onSurfaceVariant),
-              textAlign: TextAlign.center,
-            ),
-          ],
+          SizedBox(height: Spacing.smMedium),
+          Text(
+            emptyText ?? t.common.defaultEmptyList,
+            style: Typo.small.copyWith(color: colorScheme.onSurfaceVariant),
+            textAlign: TextAlign.center,
+          ),
         ],
       ),
     );

--- a/lib/i18n/common/common_en.i18n.json
+++ b/lib/i18n/common/common_en.i18n.json
@@ -146,5 +146,6 @@
     "addNew": "Add new",
     "countLeft": "$count left",
     "claimed": "claimed",
-    "anonymousLemon": "Anonymous Lemon"
+    "anonymousLemon": "Anonymous Lemon",
+    "defaultEmptyList": "No items to display at the moment."
 }

--- a/lib/i18n/event/event_en.i18n.json
+++ b/lib/i18n/event/event_en.i18n.json
@@ -180,7 +180,6 @@
         "rewards": "Rewards"
     },
     "rewards": "Rewards",
-    "noRewards": "No rewards",
     "rewardsDescription": "Enhance you guests’ experience with unique rewards and make this event stand out!",
     "addPoap": "Add POAP",
     "editEvent": "Edit event",


### PR DESCRIPTION
## Issues

- https://trello.com/c/sdChvU0B/359-add-more-spacing-below-of-event-detail
- https://trello.com/c/SsRRMUCq/360-update-button-ctas-button-layout

## What's fixed

- Add more spacing at the end of host event detail
- Fix CTA button layout of location settings page
- Fix CTA button layout of cohosts/speakers/rewards settings page
- Update wrong background color of cohosts/speakers settings page
- Display correct empty list of cohosts/speakers settings page
- Add default empty list message

## Demo

<img width="401" alt="Screenshot 2024-01-30 at 11 18 07" src="https://github.com/lemonadesocial/lemonade-flutter/assets/7247063/e71181c2-89f8-44ae-9b1c-0d457e23187d">


