### PR TITLE
fix: show view guests button for auto approve event

### DIFF
--- a/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/widgets/host_event_basic_info_card.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/widgets/host_event_basic_info_card.dart
@@ -342,90 +342,111 @@ class HostEventBasicInfoCard extends StatelessWidget {
             SizedBox(
               height: Spacing.extraSmall,
             ),
-            if (event.approvalRequired == true) ...[
-              InkWell(
-                onTap: () {
-                  Vibrate.feedback(FeedbackType.light);
-                  AutoRouter.of(context).push(
-                    const EventApprovalSettingRoute(),
-                  );
-                },
-                child: Container(
-                  height: 54.w,
-                  decoration: BoxDecoration(
-                    color: colorScheme.onPrimary.withOpacity(0.06),
-                    borderRadius: BorderRadius.only(
-                      bottomRight: Radius.circular(LemonRadius.medium),
-                      bottomLeft: Radius.circular(LemonRadius.medium),
-                      topLeft: Radius.circular(LemonRadius.extraSmall),
-                      topRight: Radius.circular(LemonRadius.extraSmall),
-                    ),
-                  ),
+            _ViewGuestsButton(event: event),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ViewGuestsButton extends StatelessWidget {
+  const _ViewGuestsButton({
+    required this.event,
+  });
+
+  final Event event;
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Translations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+
+    return InkWell(
+      onTap: () {
+        Vibrate.feedback(FeedbackType.light);
+        AutoRouter.of(context).push(
+          const EventApprovalSettingRoute(),
+        );
+      },
+      child: Container(
+        height: 54.w,
+        decoration: BoxDecoration(
+          color: colorScheme.onPrimary.withOpacity(0.06),
+          borderRadius: BorderRadius.only(
+            bottomRight: Radius.circular(LemonRadius.medium),
+            bottomLeft: Radius.circular(LemonRadius.medium),
+            topLeft: Radius.circular(LemonRadius.extraSmall),
+            topRight: Radius.circular(LemonRadius.extraSmall),
+          ),
+        ),
+        child: Stack(
+          children: [
+            Row(
+              mainAxisSize: MainAxisSize.max,
+              crossAxisAlignment: CrossAxisAlignment.center,
+              children: [
+                Expanded(
                   child: Stack(
                     children: [
-                      Row(
-                        mainAxisSize: MainAxisSize.max,
-                        crossAxisAlignment: CrossAxisAlignment.center,
-                        children: [
-                          Expanded(
-                            child: Stack(
-                              children: [
-                                Padding(
-                                  padding: EdgeInsets.symmetric(
-                                    horizontal: Spacing.smMedium,
-                                  ),
-                                  child: Row(
-                                    mainAxisAlignment: MainAxisAlignment.start,
-                                    mainAxisSize: MainAxisSize.max,
-                                    children: [
-                                      Center(
-                                        child: Assets.icons.icError.svg(
-                                          width: 20.w,
-                                          height: 20.w,
-                                        ),
-                                      ),
-                                      SizedBox(width: Spacing.small),
-                                      Text(
-                                        t.event.eventApproval.pendingRequests(
-                                          count: event.pendingRequestCount
-                                                  ?.toString() ??
-                                              0,
-                                          n: event.pendingRequestCount ?? 0,
-                                        ),
-                                        style: Typo.medium.copyWith(
-                                          color: colorScheme.onSecondary,
-                                        ),
-                                        overflow: TextOverflow.ellipsis,
-                                      ),
-                                    ],
-                                  ),
-                                ),
-                              ],
+                      Padding(
+                        padding: EdgeInsets.symmetric(
+                          horizontal: Spacing.smMedium,
+                        ),
+                        child: Row(
+                          mainAxisAlignment: MainAxisAlignment.start,
+                          mainAxisSize: MainAxisSize.max,
+                          children: [
+                            Center(
+                              child: event.approvalRequired == true
+                                  ? Assets.icons.icError.svg(
+                                      width: 20.w,
+                                      height: 20.w,
+                                    )
+                                  : Assets.icons.icGuests.svg(
+                                      width: 20.w,
+                                      height: 20.w,
+                                    ),
                             ),
-                          ),
-                          Stack(
-                            children: [
-                              SizedBox(
-                                width: Sizing.xLarge,
-                                child: Center(
-                                  child: Assets.icons.icArrowBack.svg(
-                                    width: 25.w,
-                                    height: 25.w,
-                                  ),
-                                ),
+                            SizedBox(width: Spacing.small),
+                            Text(
+                              event.approvalRequired == true
+                                  ? t.event.eventApproval.pendingRequests(
+                                      count: event.pendingRequestCount
+                                              ?.toString() ??
+                                          0,
+                                      n: event.pendingRequestCount ?? 0,
+                                    )
+                                  : t.event.eventApproval.guests,
+                              style: Typo.medium.copyWith(
+                                color: colorScheme.onSecondary,
                               ),
-                            ],
-                          ),
-                        ],
+                              overflow: TextOverflow.ellipsis,
+                            ),
+                          ],
+                        ),
                       ),
                     ],
                   ),
                 ),
-              ),
-            ],
+                Stack(
+                  children: [
+                    SizedBox(
+                      width: Sizing.xLarge,
+                      child: Center(
+                        child: Assets.icons.icArrowBack.svg(
+                          width: 25.w,
+                          height: 25.w,
+                        ),
+                      ),
+                    ),
+                  ],
+                ),
+              ],
+            ),
           ],
-        );
-      },
+        ),
+      ),
     );
   }
 }


### PR DESCRIPTION
# What ?
- Show view guests button for auto approve event 

# Why ?
- Currently, only approval required event can view the join requests and guests list, but for auto approve event, we should give host option to view guests list from exportAccepted api (this follows the logic on web)

# Screenshot 
![IMG_7888](https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/61eabe75-badf-4164-881e-d6ad515e3249)
