### PR TITLE
fix: show wrong event price on newsfeed

### DIFF
--- a/lib/core/presentation/widgets/event/event_buy_ticket_button_widget.dart
+++ b/lib/core/presentation/widgets/event/event_buy_ticket_button_widget.dart
@@ -2,6 +2,7 @@ import 'package:app/core/application/auth/auth_bloc.dart';
 import 'package:app/core/domain/event/entities/event.dart';
 import 'package:app/core/domain/event/entities/event_ticket_types.dart';
 import 'package:app/core/domain/event/input/get_event_currencies_input/get_event_currencies_input.dart';
+import 'package:app/core/domain/event/input/get_event_ticket_types_input/get_event_ticket_types_input.dart';
 import 'package:app/core/domain/event/repository/event_ticket_repository.dart';
 import 'package:app/core/presentation/widgets/loading_widget.dart';
 import 'package:app/core/presentation/widgets/theme_svg_icon_widget.dart';
@@ -27,80 +28,108 @@ class EventBuyTicketButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
-    final defaultTicketType =
-        ListUtils.findWithConditionOrFirst<EventTicketType>(
-      items: event.eventTicketTypes ?? [],
-      condition: (ticketType) => ticketType.isDefault == true,
-    );
-    final defaultPrice = ListUtils.findWithConditionOrFirst<EventTicketPrice>(
-      items: defaultTicketType?.prices ?? [],
-      condition: (price) => price.isDefault == true,
-    );
     final isLoggedIn = context.watch<AuthBloc>().state.maybeWhen(
           orElse: () => false,
           authenticated: (_) => true,
         );
 
     return FutureBuilder(
-      future: isLoggedIn
-          ? getIt<EventTicketRepository>().getEventCurrencies(
-              input: GetEventCurrenciesInput(id: event.id ?? ''),
+      future: isLoggedIn && event.eventTicketTypes?.isEmpty == true
+          ? getIt<EventTicketRepository>().getEventTicketTypes(
+              input: GetEventTicketTypesInput(
+                event: event.id ?? '',
+              ),
             )
           : Future.value(null),
-      builder: (context, snapshot) {
-        final isLoading = snapshot.connectionState == ConnectionState.waiting;
-        final currencyInfo =
-            snapshot.data?.getOrElse(() => []).firstWhereOrNull(
-                  (info) => info.currency == defaultPrice?.currency,
-                );
-        return GestureDetector(
-          child: Container(
-            padding: EdgeInsets.symmetric(
-              horizontal: Spacing.xSmall,
-              vertical: Spacing.extraSmall,
-            ),
-            decoration: ShapeDecoration(
-              gradient: LinearGradient(
-                begin: const Alignment(0.00, -1.00),
-                end: const Alignment(0, 1),
-                colors: [LemonColor.arsenic, LemonColor.charlestonGreen],
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(LemonRadius.normal),
-              ),
-              shadows: [
-                BoxShadow(
-                  color: LemonColor.shadow,
-                  blurRadius: 4,
-                  offset: const Offset(0, 2),
-                  spreadRadius: 0,
+      builder: (context, ticketTypesSnapshot) {
+        List<EventTicketType>? ticketTypes =
+            ticketTypesSnapshot.data?.fold((l) => [], (r) {
+          return r.ticketTypes
+              ?.map(
+                (item) => EventTicketType(
+                  id: item.id,
+                  title: item.title,
+                  prices: item.prices,
+                  isDefault: item.isDefault,
                 ),
-              ],
-            ),
-            child: Row(
-              children: [
-                ThemeSvgIcon(
-                  color: colorScheme.onPrimary,
-                  builder: (filter) => Assets.icons.icTicket.svg(
-                    width: Sizing.xSmall,
-                    height: Sizing.xSmall,
-                    colorFilter: filter,
+              )
+              .toList();
+        });
+        final defaultTicketType =
+            ListUtils.findWithConditionOrFirst<EventTicketType>(
+          items: ticketTypes ?? event.eventTicketTypes ?? [],
+          condition: (ticketType) => ticketType.isDefault == true,
+        );
+        final defaultPrice =
+            ListUtils.findWithConditionOrFirst<EventTicketPrice>(
+          items: defaultTicketType?.prices ?? [],
+          condition: (price) => price.isDefault == true,
+        );
+        return FutureBuilder(
+          future: isLoggedIn
+              ? getIt<EventTicketRepository>().getEventCurrencies(
+                  input: GetEventCurrenciesInput(id: event.id ?? ''),
+                )
+              : Future.value(null),
+          builder: (context, snapshot) {
+            final isLoading = ticketTypesSnapshot.connectionState ==
+                    ConnectionState.waiting ||
+                snapshot.connectionState == ConnectionState.waiting;
+            final currencyInfo =
+                snapshot.data?.getOrElse(() => []).firstWhereOrNull(
+                      (info) => info.currency == defaultPrice?.currency,
+                    );
+            return GestureDetector(
+              child: Container(
+                padding: EdgeInsets.symmetric(
+                  horizontal: Spacing.xSmall,
+                  vertical: Spacing.extraSmall,
+                ),
+                decoration: ShapeDecoration(
+                  gradient: LinearGradient(
+                    begin: const Alignment(0.00, -1.00),
+                    end: const Alignment(0, 1),
+                    colors: [LemonColor.arsenic, LemonColor.charlestonGreen],
                   ),
-                ),
-                SizedBox(width: Spacing.superExtraSmall),
-                if (isLoading)
-                  Loading.defaultLoading(context)
-                else
-                  Text(
-                    EventTicketUtils.getDisplayedTicketPrice(
-                      decimals: currencyInfo?.decimals?.toInt(),
-                      price: defaultPrice,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(LemonRadius.normal),
+                  ),
+                  shadows: [
+                    BoxShadow(
+                      color: LemonColor.shadow,
+                      blurRadius: 4,
+                      offset: const Offset(0, 2),
+                      spreadRadius: 0,
                     ),
-                    style: Typo.small.copyWith(color: colorScheme.onPrimary),
-                  ),
-              ],
-            ),
-          ),
+                  ],
+                ),
+                child: Row(
+                  children: [
+                    ThemeSvgIcon(
+                      color: colorScheme.onPrimary,
+                      builder: (filter) => Assets.icons.icTicket.svg(
+                        width: Sizing.xSmall,
+                        height: Sizing.xSmall,
+                        colorFilter: filter,
+                      ),
+                    ),
+                    SizedBox(width: Spacing.superExtraSmall),
+                    if (isLoading)
+                      Loading.defaultLoading(context)
+                    else
+                      Text(
+                        EventTicketUtils.getDisplayedTicketPrice(
+                          decimals: currencyInfo?.decimals?.toInt(),
+                          price: defaultPrice,
+                        ),
+                        style:
+                            Typo.small.copyWith(color: colorScheme.onPrimary),
+                      ),
+                  ],
+                ),
+              ),
+            );
+          },
         );
       },
     );


### PR DESCRIPTION
# What ?
- Fix show wrong event price on newsfeed
https://trello.com/c/wFBqFiHb/381-home-always-display-free-price-event-on-home-screen

Please note that api has authentication, so if user is not logged in, cannot get the event ticket types => showing free

# Screenshot 
<img width="530" alt="Screenshot 2024-02-27 at 12 13 55" src="https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/dcae44a2-e23c-4c35-a9df-05db6fd8cc31">
