### PR TITLE
fix: handle fallback for payment flow when noti not coming up for too long

### DIFF
--- a/lib/core/application/event_tickets/get_my_tickets_bloc/get_my_tickets_bloc.dart
+++ b/lib/core/application/event_tickets/get_my_tickets_bloc/get_my_tickets_bloc.dart
@@ -21,9 +21,7 @@ class GetMyTicketsBloc extends Bloc<GetMyTicketsEvent, GetMyTicketsState> {
     GetMyTicketsEventFetch event,
     Emitter emit,
   ) async {
-    if (state is! GetMyTicketsStateSuccess) {
-      emit(GetMyTicketsState.loading());
-    }
+    emit(GetMyTicketsState.loading());
 
     final result = await _eventTicketRepository.getTickets(input: input);
 

--- a/lib/core/data/payment/payment_query.dart
+++ b/lib/core/data/payment/payment_query.dart
@@ -109,3 +109,13 @@ final getPaymentAccountsQuery = gql('''
     }
   }
 ''');
+
+final getPaymentQuery = gql('''
+  $paymentFragment
+
+  query GetNewPayment(\$id: MongoID!) {
+    getNewPayment(_id: \$id) {
+      ...paymentFragment
+    }
+  }
+''');

--- a/lib/core/data/payment/payment_repository_impl.dart
+++ b/lib/core/data/payment/payment_repository_impl.dart
@@ -11,6 +11,7 @@ import 'package:app/core/domain/payment/entities/payment_card/payment_card.dart'
 import 'package:app/core/domain/payment/input/create_payment_account_input/create_payment_account_input.dart';
 import 'package:app/core/domain/payment/input/create_stripe_card_input/create_stripe_card_input.dart';
 import 'package:app/core/domain/payment/input/get_payment_accounts_input/get_payment_accounts_input.dart';
+import 'package:app/core/domain/payment/input/get_payment_input/get_payment_input.dart';
 import 'package:app/core/domain/payment/input/get_stripe_cards_input/get_stripe_cards_input.dart';
 import 'package:app/core/domain/payment/input/update_payment_input/update_payment_input.dart';
 import 'package:app/core/domain/payment/payment_repository.dart';
@@ -68,6 +69,29 @@ class PaymentRepositoryImpl extends PaymentRepository {
       return Left(Failure.withGqlException(result.exception));
     }
     return Right(result.parsedData!);
+  }
+
+  @override
+  Future<Either<Failure, Payment?>> getPayment({
+    required GetPaymentInput input,
+  }) async {
+    final result = await _client.mutate(
+      MutationOptions(
+        document: getPaymentQuery,
+        variables: input.toJson(),
+        fetchPolicy: FetchPolicy.networkOnly,
+        parserFn: (data) => data['getNewPayment'] != null
+            ? Payment.fromDto(
+                PaymentDto.fromJson(
+                  data['getNewPayment'],
+                ),
+              )
+            : null,
+      ),
+    );
+
+    if (result.hasException) return Left(Failure());
+    return Right(result.parsedData);
   }
 
   @override

--- a/lib/core/data/web3/dtos/chain_dto.dart
+++ b/lib/core/data/web3/dtos/chain_dto.dart
@@ -11,6 +11,8 @@ class ChainDto with _$ChainDto {
     String? name,
     @JsonKey(name: 'rpc_url') String? rpcUrl,
     @JsonKey(name: 'logo_url') String? logoUrl,
+    @JsonKey(name: 'block_time') double? blockTime,
+    @JsonKey(name: 'safe_confirmations') double? safeConfirmations,
     List<ERC20TokenDto>? tokens,
   }) = _ChainDto;
 

--- a/lib/core/data/web3/web3_query.dart
+++ b/lib/core/data/web3/web3_query.dart
@@ -8,6 +8,8 @@ final getChainsListQuery = gql('''
       name
       rpc_url
       logo_url
+      block_time
+      safe_confirmations
       tokens {
         active
         name

--- a/lib/core/domain/payment/input/get_payment_input/get_payment_input.dart
+++ b/lib/core/domain/payment/input/get_payment_input/get_payment_input.dart
@@ -1,0 +1,14 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'get_payment_input.freezed.dart';
+part 'get_payment_input.g.dart';
+
+@freezed
+class GetPaymentInput with _$GetPaymentInput {
+  factory GetPaymentInput({
+    required String id,
+  }) = _GetPaymentInput;
+
+  factory GetPaymentInput.fromJson(Map<String, dynamic> json) =>
+      _$GetPaymentInputFromJson(json);
+}

--- a/lib/core/domain/payment/payment_repository.dart
+++ b/lib/core/domain/payment/payment_repository.dart
@@ -4,6 +4,7 @@ import 'package:app/core/domain/payment/entities/payment_card/payment_card.dart'
 import 'package:app/core/domain/payment/input/create_payment_account_input/create_payment_account_input.dart';
 import 'package:app/core/domain/payment/input/create_stripe_card_input/create_stripe_card_input.dart';
 import 'package:app/core/domain/payment/input/get_payment_accounts_input/get_payment_accounts_input.dart';
+import 'package:app/core/domain/payment/input/get_payment_input/get_payment_input.dart';
 import 'package:app/core/domain/payment/input/get_stripe_cards_input/get_stripe_cards_input.dart';
 import 'package:app/core/domain/payment/input/update_payment_input/update_payment_input.dart';
 import 'package:app/core/failure.dart';
@@ -16,6 +17,10 @@ abstract class PaymentRepository {
 
   Future<Either<Failure, PaymentCard>> createStripeCard({
     required CreateStripeCardInput input,
+  });
+
+  Future<Either<Failure, Payment?>> getPayment({
+    required GetPaymentInput input,
   });
 
   Future<Either<Failure, Payment?>> updatePayment({

--- a/lib/core/domain/web3/entities/chain.dart
+++ b/lib/core/domain/web3/entities/chain.dart
@@ -16,6 +16,8 @@ class Chain with _$Chain {
     String? logoUrl,
     List<ERC20Token>? tokens,
     ERC20Token? nativeToken,
+    double? blockTime,
+    double? safeConfirmations,
   }) = _Chain;
 
   factory Chain.fromDto(ChainDto dto) {
@@ -34,6 +36,8 @@ class Chain with _$Chain {
       logoUrl: dto.logoUrl,
       tokens: tokens,
       nativeToken: nativeToken,
+      blockTime: dto.blockTime,
+      safeConfirmations: dto.safeConfirmations,
     );
   }
 }

--- a/lib/core/presentation/pages/event_tickets/event_buy_tickets_page/sub_pages/event_pick_my_ticket_page/widgets/pick_my_tickets_list.dart
+++ b/lib/core/presentation/pages/event_tickets/event_buy_tickets_page/sub_pages/event_pick_my_ticket_page/widgets/pick_my_tickets_list.dart
@@ -1,3 +1,4 @@
+import 'package:app/core/application/event_tickets/get_my_tickets_bloc/get_my_tickets_bloc.dart';
 import 'package:app/core/application/event_tickets/select_self_assign_ticket_bloc/select_self_assign_ticket_bloc.dart';
 import 'package:app/core/domain/event/entities/event.dart';
 import 'package:app/core/domain/event/entities/event_ticket_types.dart';
@@ -28,32 +29,39 @@ class PickMyTicketsList extends StatelessWidget {
         child: Column(
           children: [
             Expanded(
-              child: ListView.separated(
-                itemBuilder: (context, index) {
-                  final group = ticketGroupsMap.entries.toList()[index];
-                  final ticketTypeId = group.key;
-                  final total = group.value.length.toDouble();
-                  final ticketType = ticketTypes.firstWhereOrNull(
-                    (mTicketType) => mTicketType.id == ticketTypeId,
-                  );
-
-                  return PickTicketItem(
-                    ticketType: ticketType,
-                    total: total,
-                    currency: event.currency,
-                    selected: state.selectedTicketType == ticketTypeId,
-                    onPressed: () =>
-                        context.read<SelectSelfAssignTicketBloc>().add(
-                              SelectSelfAssignTicketEvent.select(
-                                ticketTypeId: ticketTypeId,
-                              ),
-                            ),
-                  );
+              child: RefreshIndicator(
+                onRefresh: () async {
+                  context.read<GetMyTicketsBloc>().add(
+                        GetMyTicketsEvent.fetch(),
+                      );
                 },
-                separatorBuilder: (context, index) => SizedBox(
-                  height: Spacing.xSmall,
+                child: ListView.separated(
+                  itemBuilder: (context, index) {
+                    final group = ticketGroupsMap.entries.toList()[index];
+                    final ticketTypeId = group.key;
+                    final total = group.value.length.toDouble();
+                    final ticketType = ticketTypes.firstWhereOrNull(
+                      (mTicketType) => mTicketType.id == ticketTypeId,
+                    );
+
+                    return PickTicketItem(
+                      ticketType: ticketType,
+                      total: total,
+                      currency: event.currency,
+                      selected: state.selectedTicketType == ticketTypeId,
+                      onPressed: () =>
+                          context.read<SelectSelfAssignTicketBloc>().add(
+                                SelectSelfAssignTicketEvent.select(
+                                  ticketTypeId: ticketTypeId,
+                                ),
+                              ),
+                    );
+                  },
+                  separatorBuilder: (context, index) => SizedBox(
+                    height: Spacing.xSmall,
+                  ),
+                  itemCount: ticketGroupsMap.length,
                 ),
-                itemCount: ticketGroupsMap.length,
               ),
             ),
           ],

--- a/lib/core/presentation/pages/event_tickets/event_buy_tickets_page/sub_pages/event_tickets_summary_page/handler/wait_for_payment_notification_handler.dart
+++ b/lib/core/presentation/pages/event_tickets/event_buy_tickets_page/sub_pages/event_tickets_summary_page/handler/wait_for_payment_notification_handler.dart
@@ -12,14 +12,16 @@ import 'package:flutter/material.dart';
 class WaitForPaymentNotificationHandler {
   Timer? timer;
 
+  static get maxDurationToWaitForNotification => const Duration(minutes: 3);
+
+  static get delayIntervalDuration => const Duration(seconds: 5);
+
   Future<Payment?> _checkPayment(String paymentId) async {
     int remainingAttempt = 10;
     Payment? payment;
     while (remainingAttempt > 0) {
       Future.delayed(
-        const Duration(
-          seconds: 5,
-        ),
+        delayIntervalDuration,
       );
       final paymentResult = await getIt<PaymentRepository>().getPayment(
         input: GetPaymentInput(
@@ -44,7 +46,7 @@ class WaitForPaymentNotificationHandler {
     Function()? onPaymentDone,
     Function()? onPaymentFailed,
   }) async {
-    timer = Timer(const Duration(minutes: 3), () async {
+    timer = Timer(maxDurationToWaitForNotification, () async {
       final paymentResult = await getIt<PaymentRepository>().getPayment(
         input: GetPaymentInput(
           id: paymentId,
@@ -71,14 +73,14 @@ class WaitForPaymentNotificationHandler {
     Function()? onPaymentDone,
     Function()? onPaymentFailed,
   }) async {
-    timer = Timer(const Duration(minutes: 3), () async {
+    timer = Timer(maxDurationToWaitForNotification, () async {
       final getChainResult =
           await getIt<Web3Repository>().getChainById(chainId: chainId);
       final chain = getChainResult.getOrElse(() => null);
       final receipt = await Web3Utils.waitForReceipt(
         rpcUrl: chain?.rpcUrl ?? '',
         txHash: txHash,
-        deplayDuration: const Duration(seconds: 5),
+        deplayDuration: delayIntervalDuration,
       );
       // This make sure BE already confirmed after transaction receipt is retured
       await Future.delayed(

--- a/lib/core/utils/web3_utils.dart
+++ b/lib/core/utils/web3_utils.dart
@@ -75,4 +75,30 @@ class Web3Utils {
   static String removeTrailingZeros(String n) {
     return n.replaceAll(RegExp(r"([.]*0+)(?!.*\d)"), "");
   }
+
+  static Future<TransactionReceipt?> waitForReceipt({
+    required String rpcUrl,
+    required String txHash,
+    int maxAttempt = 10,
+    Duration? deplayDuration,
+  }) async {
+    final web3Client = Web3Client(rpcUrl, http.Client());
+    TransactionReceipt? receipt;
+    int remainingAttempt = maxAttempt;
+    while (remainingAttempt > 0) {
+      await Future.delayed(
+        deplayDuration ??
+            const Duration(
+              seconds: 0,
+            ),
+      );
+      receipt = await web3Client.getTransactionReceipt(txHash);
+      if (receipt != null) {
+        return receipt;
+      }
+      remainingAttempt--;
+    }
+
+    return receipt;
+  }
 }


### PR DESCRIPTION
# What ?
Fallback for payment flow if payment success notification not come up for too long then what to do is
- For fiat :manually check the payment status and proceed next step 
- For crypto: manually check the receipt status and payment status => proceed next step

- Add pull to refresh for pick my tickets page 
