### PR TITLE
fix: remove unnecessary navigate to event select category if categories is empty or only 1 item

### DIFF
--- a/lib/core/presentation/pages/event_tickets/event_buy_tickets_page/sub_pages/event_buy_tickets_initial_page/event_buy_tickets_initial_page.dart
+++ b/lib/core/presentation/pages/event_tickets/event_buy_tickets_page/sub_pages/event_buy_tickets_initial_page/event_buy_tickets_initial_page.dart
@@ -1,8 +1,12 @@
 import 'package:app/core/application/event/event_provider_bloc/event_provider_bloc.dart';
 import 'package:app/core/application/event_tickets/get_my_tickets_bloc/get_my_tickets_bloc.dart';
+import 'package:app/core/application/event_tickets/select_event_tickets_bloc/select_event_tickets_bloc.dart';
+import 'package:app/core/domain/event/input/get_event_ticket_types_input/get_event_ticket_types_input.dart';
 import 'package:app/core/domain/event/input/get_tickets_input/get_tickets_input.dart';
+import 'package:app/core/domain/event/repository/event_ticket_repository.dart';
 import 'package:app/core/presentation/widgets/loading_widget.dart';
 import 'package:app/core/utils/auth_utils.dart';
+import 'package:app/injection/register_module.dart';
 import 'package:app/router/app_router.gr.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
@@ -39,6 +43,7 @@ class EventBuyTicketsInitialPageView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final colorScheme = Theme.of(context).colorScheme;
+    final event = context.read<EventProviderBloc>().event;
 
     return BlocListener<GetMyTicketsBloc, GetMyTicketsState>(
       listener: (context, state) {
@@ -49,16 +54,45 @@ class EventBuyTicketsInitialPageView extends StatelessWidget {
               const EventBuyTicketsSelectTicketCategoryRoute(),
             );
           },
-          success: (eventTickets) {
-            if (eventTickets.isEmpty) {
-              AutoRouter.of(context).replace(
-                const EventBuyTicketsSelectTicketCategoryRoute(),
-              );
-            } else {
+          success: (eventTickets) async {
+            if (eventTickets.isNotEmpty) {
               AutoRouter.of(context).replace(
                 const EventPickMyTicketRoute(),
               );
+              return;
             }
+
+            final response =
+                await getIt<EventTicketRepository>().getEventTicketTypes(
+              input: GetEventTicketTypesInput(event: event.id ?? ''),
+            );
+            response.fold((failure) {
+              AutoRouter.of(context).replace(
+                const EventBuyTicketsSelectTicketCategoryRoute(),
+              );
+            }, (response) {
+              final allTickets = response.ticketTypes ?? [];
+              final allCategories = allTickets
+                  .where((element) => element.categoryExpanded != null)
+                  .map((e) => e.categoryExpanded!)
+                  .toSet()
+                  .toList();
+              if (allCategories.isEmpty || allCategories.length == 1) {
+                context.read<SelectEventTicketsBloc>().add(
+                      SelectEventTicketsEvent.selectTicketCategory(
+                        category:
+                            allCategories.isEmpty ? null : allCategories.first,
+                      ),
+                    );
+                context.router.replace(
+                  const SelectTicketsRoute(),
+                );
+              } else {
+                AutoRouter.of(context).replace(
+                  const EventBuyTicketsSelectTicketCategoryRoute(),
+                );
+              }
+            });
           },
         );
       },


### PR DESCRIPTION
# What ?
- remove unnecessary navigate to event select category if categories is empty or only 1 item

# Screenshot 

https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/28fe393e-8fc1-46e6-924a-f179167df693

