### PR TITLE
fix: move all logic check at event buy button to bloc

### DIFF
--- a/lib/core/application/event/event_buy_tickets_prerequisite_check_bloc/event_buy_tickets_prerequisite_check_bloc.dart
+++ b/lib/core/application/event/event_buy_tickets_prerequisite_check_bloc/event_buy_tickets_prerequisite_check_bloc.dart
@@ -1,0 +1,118 @@
+import 'package:app/core/domain/event/entities/event.dart';
+import 'package:app/core/domain/event/entities/event_join_request.dart';
+import 'package:app/core/domain/event/event_repository.dart';
+import 'package:app/core/domain/user/entities/user.dart';
+import 'package:app/core/domain/user/user_repository.dart';
+import 'package:app/core/utils/event_utils.dart';
+import 'package:app/core/utils/string_utils.dart';
+import 'package:app/injection/register_module.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'event_buy_tickets_prerequisite_check_bloc.freezed.dart';
+
+class EventBuyTicketsPrerequisiteCheckBloc extends Bloc<
+    EventBuyTicketsPrerequisiteCheckEvent,
+    EventBuyTicketsPrerequisiteCheckState> {
+  final Event event;
+  EventBuyTicketsPrerequisiteCheckBloc({
+    required this.event,
+  }) : super(EventBuyTicketsPrerequisiteCheckState.initial()) {
+    on<_EventBuyTicketsPrerequisiteCheck>(_onCheck);
+  }
+
+  void _onCheck(
+    _EventBuyTicketsPrerequisiteCheck blocEvent,
+    Emitter emit,
+  ) async {
+    emit(EventBuyTicketsPrerequisiteCheckState.checking());
+
+    if (event.private == true) {
+      if (!EventUtils.isInvited(event, userId: blocEvent.userId)) {
+        emit(EventBuyTicketsPrerequisiteCheckState.isNotInvited());
+        return;
+      }
+    }
+
+    final joinRequest = await _checkEventJoinRequest();
+    if (joinRequest != null) {
+      emit(
+        EventBuyTicketsPrerequisiteCheckState.hasJoinRequest(
+          eventJoinRequest: joinRequest,
+        ),
+      );
+      return;
+    }
+
+    final checkApplicationResult = await _checkApplicationFormCompleted();
+    final isCompleted = checkApplicationResult.value1;
+    final user = checkApplicationResult.value2;
+    if (!isCompleted) {
+      return emit(
+        EventBuyTicketsPrerequisiteCheckState.applicationFormNotCompleted(
+          user: user!,
+        ),
+      );
+    }
+
+    emit(EventBuyTicketsPrerequisiteCheckState.allPassed());
+  }
+
+  Future<EventJoinRequest?> _checkEventJoinRequest() async {
+    final result = await getIt<EventRepository>()
+        .getMyEventJoinRequest(eventId: event.id ?? '');
+    return result.fold((l) => null, (r) => r);
+  }
+
+  Future<Tuple2<bool, User?>> _checkApplicationFormCompleted() async {
+    List<String> profileRequiredFields = (event.applicationProfileFields ?? [])
+        .where((e) => e.required == true)
+        .map((e) => e.field ?? '')
+        .map(StringUtils.snakeToCamel)
+        .toList();
+
+    final userResult = await getIt<UserRepository>().getMe();
+
+    User? user = userResult.fold((l) => null, (user) => user);
+    if (user != null) {
+      final alreadySubmitted = event.applicationFormSubmission != null;
+      final hasRequiredProfileFields = profileRequiredFields.isNotEmpty;
+      final hasApplicationQuestions =
+          event.applicationQuestions?.isNotEmpty ?? false;
+      if ((hasRequiredProfileFields && !alreadySubmitted) ||
+          (hasApplicationQuestions && !alreadySubmitted)) {
+        return Tuple2(false, user);
+      }
+      return Tuple2(true, user);
+    }
+    return Tuple2(true, user);
+  }
+}
+
+@freezed
+class EventBuyTicketsPrerequisiteCheckEvent
+    with _$EventBuyTicketsPrerequisiteCheckEvent {
+  factory EventBuyTicketsPrerequisiteCheckEvent.check({
+    required String userId,
+  }) = _EventBuyTicketsPrerequisiteCheck;
+}
+
+@freezed
+class EventBuyTicketsPrerequisiteCheckState
+    with _$EventBuyTicketsPrerequisiteCheckState {
+  factory EventBuyTicketsPrerequisiteCheckState.initial() =
+      EventBuyTicketsPrerequisiteCheckStateInitial;
+  factory EventBuyTicketsPrerequisiteCheckState.checking() =
+      EventBuyTicketsPrerequisiteCheckStateChecking;
+  factory EventBuyTicketsPrerequisiteCheckState.isNotInvited() =
+      EventBuyTicketsPrerequisiteCheckStateIsNotInvited;
+  factory EventBuyTicketsPrerequisiteCheckState.hasJoinRequest({
+    required EventJoinRequest eventJoinRequest,
+  }) = EventBuyTicketsPrerequisiteCheckStateHasJoinRequest;
+  factory EventBuyTicketsPrerequisiteCheckState.applicationFormNotCompleted({
+    required User user,
+  }) = EventBuyTicketsPrerequisiteCheckStateApplicationFormNotCompleted;
+  factory EventBuyTicketsPrerequisiteCheckState.allPassed() =
+      EventBuyTicketsPrerequisiteCheckStateAllPassed;
+}

--- a/lib/core/presentation/pages/event/event_detail_page/guest_event_detail_page/widgets/guest_event_detail_buy_button.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/guest_event_detail_page/widgets/guest_event_detail_buy_button.dart
@@ -1,34 +1,24 @@
 import 'package:app/core/application/auth/auth_bloc.dart';
-import 'package:app/core/application/event/buy_event_ticket_bloc/buy_event_ticket_bloc.dart';
+import 'package:app/core/application/event/event_buy_tickets_prerequisite_check_bloc/event_buy_tickets_prerequisite_check_bloc.dart';
 import 'package:app/core/domain/event/entities/event.dart';
-import 'package:app/core/domain/event/entities/event_join_request.dart';
 import 'package:app/core/domain/event/entities/event_ticket_types.dart';
-import 'package:app/core/domain/event/event_repository.dart';
-import 'package:app/core/domain/event/input/get_event_currencies_input/get_event_currencies_input.dart';
-import 'package:app/core/domain/event/repository/event_ticket_repository.dart';
-import 'package:app/core/domain/user/entities/user.dart';
-import 'package:app/core/domain/user/user_repository.dart';
-import 'package:app/core/failure.dart';
+import 'package:app/core/domain/payment/entities/payment_account/payment_account.dart';
 import 'package:app/core/presentation/widgets/common/button/linear_gradient_button_widget.dart';
-import 'package:app/core/presentation/widgets/future_loading_dialog.dart';
 import 'package:app/core/presentation/widgets/theme_svg_icon_widget.dart';
 import 'package:app/core/utils/auth_utils.dart';
 import 'package:app/core/utils/event_tickets_utils.dart';
-import 'package:app/core/utils/event_utils.dart';
 import 'package:app/core/utils/list_utils.dart';
-import 'package:app/core/utils/string_utils.dart';
 import 'package:app/gen/assets.gen.dart';
 import 'package:app/gen/fonts.gen.dart';
-import 'package:app/injection/register_module.dart';
 import 'package:app/router/app_router.gr.dart';
 import 'package:app/theme/sizing.dart';
 import 'package:app/theme/spacing.dart';
 import 'package:app/theme/typo.dart';
 import 'package:auto_route/auto_route.dart';
-import 'package:dartz/dartz.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:collection/collection.dart';
+import 'package:matrix/matrix.dart' as matrix;
 
 class GuestEventDetailBuyButton extends StatelessWidget {
   const GuestEventDetailBuyButton({
@@ -41,7 +31,7 @@ class GuestEventDetailBuyButton extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (context) => BuyEventTicketBloc(event: event),
+      create: (context) => EventBuyTicketsPrerequisiteCheckBloc(event: event),
       child: _GuestEventDetailBuyButtonView(
         event: event,
       ),
@@ -56,81 +46,68 @@ class _GuestEventDetailBuyButtonView extends StatelessWidget {
 
   final Event event;
 
-  Future<Either<Failure, EventJoinRequest?>?> _checkJoinRequest(
-    BuildContext context,
-  ) async {
-    final result =
-        await showFutureLoadingDialog<Either<Failure, EventJoinRequest?>>(
-      context: context,
-      future: () => getIt<EventRepository>()
-          .getMyEventJoinRequest(eventId: event.id ?? ''),
-    );
-    return result.result;
-  }
-
-  Future<void> _checkProfileRequiredFields(BuildContext context) async {
-    List<String> profileRequiredFields = (event.applicationProfileFields ?? [])
-        .where((e) => e.required == true)
-        .map((e) => e.field ?? '')
-        .map(StringUtils.snakeToCamel)
-        .toList();
-
-    final userResult = await showFutureLoadingDialog(
-      context: context,
-      future: () => getIt<UserRepository>().getMe(),
+  String getDislayPrice() {
+    final defaultTicketType =
+        ListUtils.findWithConditionOrFirst<EventTicketType>(
+      items: event.eventTicketTypes ?? [],
+      condition: (ticketType) => ticketType.isDefault == true,
     );
 
-    User? user = userResult.result?.fold((l) => null, (user) => user);
-    if (user != null) {
-      final alreadySubmitted = event.applicationFormSubmission != null;
-      final hasRequiredProfileFields = profileRequiredFields.isNotEmpty;
-      final hasApplicationQuestions =
-          event.applicationQuestions?.isNotEmpty ?? false;
-      if ((hasRequiredProfileFields && !alreadySubmitted) ||
-          (hasApplicationQuestions && !alreadySubmitted)) {
-        AutoRouter.of(context)
-            .navigate(GuestEventApplicationRoute(event: event, user: user));
-      } else {
-        AutoRouter.of(context).navigate(EventBuyTicketsRoute(event: event));
-      }
-    }
-    return;
-  }
+    final defaultPrice = ListUtils.findWithConditionOrFirst<EventTicketPrice>(
+      items: defaultTicketType?.prices ?? [],
+      condition: (price) => price.isDefault == true,
+    );
 
-  bool _checkInvited(BuildContext context) {
-    final userId = AuthUtils.getUserId(context);
-    return EventUtils.isInvited(event, userId: userId);
+    final targetPaymentAccount =
+        (event.paymentAccountsExpanded ?? []).firstWhereOrNull(
+      (element) =>
+          element.accountInfo?.currencies?.contains(defaultPrice?.currency) ==
+          true,
+    );
+
+    final decimals = targetPaymentAccount?.accountInfo?.currencyMap
+            ?.tryGet<CurrencyInfo>(defaultPrice?.currency ?? '')
+            ?.decimals ??
+        0;
+
+    return EventTicketUtils.getDisplayedTicketPrice(
+      decimals: decimals,
+      price: defaultPrice,
+    );
   }
 
   @override
   Widget build(BuildContext context) {
     final authState = context.watch<AuthBloc>().state;
     final colorScheme = Theme.of(context).colorScheme;
-    final defaultTicketType =
-        ListUtils.findWithConditionOrFirst<EventTicketType>(
-      items: event.eventTicketTypes ?? [],
-      condition: (ticketType) => ticketType.isDefault == true,
-    );
-    final defaultPrice = ListUtils.findWithConditionOrFirst<EventTicketPrice>(
-      items: defaultTicketType?.prices ?? [],
-      condition: (price) => price.isDefault == true,
-    );
-    final isLoggedIn = context.watch<AuthBloc>().state.maybeWhen(
-          orElse: () => false,
-          authenticated: (_) => true,
+    final userId = AuthUtils.getUserId(context);
+
+    return BlocConsumer<EventBuyTicketsPrerequisiteCheckBloc,
+        EventBuyTicketsPrerequisiteCheckState>(
+      listener: (context, state) {
+        state.maybeWhen(
+          orElse: () => null,
+          isNotInvited: () => AutoRouter.of(context).push(
+            const GuestEventPrivateAlertRoute(),
+          ),
+          hasJoinRequest: (joinRequest) => AutoRouter.of(context).push(
+            GuestEventApprovalStatusRoute(
+              event: event,
+              eventJoinRequest: joinRequest,
+            ),
+          ),
+          applicationFormNotCompleted: (user) =>
+              AutoRouter.of(context).navigate(
+            GuestEventApplicationRoute(event: event, user: user),
+          ),
+          allPassed: () => AutoRouter.of(context).navigate(
+            EventBuyTicketsRoute(event: event),
+          ),
         );
-    return FutureBuilder(
-      future: isLoggedIn
-          ? getIt<EventTicketRepository>().getEventCurrencies(
-              input: GetEventCurrenciesInput(id: event.id ?? ''),
-            )
-          : Future.value(null),
-      builder: (context, snapshot) {
-        final isLoading = snapshot.connectionState == ConnectionState.waiting;
-        final currencyInfo =
-            snapshot.data?.getOrElse(() => []).firstWhereOrNull(
-                  (info) => info.currency == defaultPrice?.currency,
-                );
+      },
+      builder: (context, state) {
+        final isLoading =
+            state is EventBuyTicketsPrerequisiteCheckStateChecking;
         return SafeArea(
           child: Container(
             color: colorScheme.primary,
@@ -142,28 +119,16 @@ class _GuestEventDetailBuyButtonView extends StatelessWidget {
               height: Sizing.large,
               child: LinearGradientButton(
                 onTap: () {
+                  if (isLoading) {
+                    return;
+                  }
                   authState.maybeWhen(
                     authenticated: (_) async {
-                      if (event.private == true) {
-                        if (!_checkInvited(context)) {
-                          AutoRouter.of(context)
-                              .push(const GuestEventPrivateAlertRoute());
-                          return;
-                        }
-                      }
-                      final result = await _checkJoinRequest(context);
-                      final eventJoinRequest = result?.getOrElse(() => null);
-                      if (eventJoinRequest != null) {
-                        AutoRouter.of(context).push(
-                          GuestEventApprovalStatusRoute(
-                            event: event,
-                            eventJoinRequest: eventJoinRequest,
-                          ),
-                        );
-                        return;
-                      }
-
-                      await _checkProfileRequiredFields(context);
+                      context.read<EventBuyTicketsPrerequisiteCheckBloc>().add(
+                            EventBuyTicketsPrerequisiteCheckEvent.check(
+                              userId: userId,
+                            ),
+                          );
                     },
                     orElse: () {
                       AutoRouter.of(context).navigate(
@@ -177,10 +142,7 @@ class _GuestEventDetailBuyButtonView extends StatelessWidget {
                   builder: (filter) =>
                       Assets.icons.icTicketBold.svg(colorFilter: filter),
                 ),
-                label: EventTicketUtils.getDisplayedTicketPrice(
-                  decimals: currencyInfo?.decimals?.toInt(),
-                  price: defaultPrice,
-                ),
+                label: getDislayPrice(),
                 radius: BorderRadius.circular(LemonRadius.small * 2),
                 mode: GradientButtonMode.lavenderMode,
                 loadingWhen: isLoading,


### PR DESCRIPTION
# What ?
 - Move all prerequisite check before buying event tickets to bloc 
 
# Screenshot

https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/9f5fff93-cfa2-41cc-8476-06fffb5b535e

