### PR TITLE
fix: enhance sentry stack trace when calling gql

### DIFF
--- a/lib/core/utils/gql/custom_error_handler.dart
+++ b/lib/core/utils/gql/custom_error_handler.dart
@@ -84,7 +84,7 @@ class CustomErrorHandler {
     showSnackbarError(errorCode, errorMessage);
     CrashAnalyticsManager().crashAnalyticsService?.captureError(
           errors,
-          StackTrace.fromString(errors.toString()),
+          StackTrace.fromString(request.toString()),
         );
     FirebaseCrashlytics.instance.log(response.errors.toString());
     return null;


### PR DESCRIPTION
# What ?
- Mark gql request as a stack trace to navigate which api causing error 
<img width="1509" alt="Screenshot 2024-04-02 at 13 57 20" src="https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/df1a7ff9-c8f4-42eb-9a9f-3108515e8ebb">
