### PR TITLE
fix: crash in community page

### DIFF
--- a/lib/core/presentation/pages/community/community_page.dart
+++ b/lib/core/presentation/pages/community/community_page.dart
@@ -13,7 +13,6 @@ import 'package:app/theme/typo.dart';
 import 'package:auto_route/annotations.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:flutter_screenutil/flutter_screenutil.dart';
 
 @RoutePage()
 class CommunityPage extends StatelessWidget {


### PR DESCRIPTION
## Overview

- https://trello.com/c/09Pat7O8/530-crash-in-community-page

## Demo

<img width="398" alt="Screenshot 2024-05-02 at 11 36 27" src="https://github.com/lemonadesocial/lemonade-flutter/assets/7247063/a7faa82d-75c2-46c9-91e7-a431f8ec7f0b">

<img width="399" alt="Screenshot 2024-05-02 at 11 36 32" src="https://github.com/lemonadesocial/lemonade-flutter/assets/7247063/9f7484c9-590f-4c61-b2e2-358277bc4577">

