### PR TITLE
fix: crash problem in notifications screen

### DIFF
--- a/lib/core/presentation/pages/create_post/widgets/create_post_event_card_widget.dart
+++ b/lib/core/presentation/pages/create_post/widgets/create_post_event_card_widget.dart
@@ -45,7 +45,7 @@ class CreatePostEventCardWidget extends StatelessWidget {
                     placeholder: (_, __) => ImagePlaceholder.eventCard(),
                     errorWidget: (_, __, ___) => ImagePlaceholder.eventCard(),
                     imageUrl: ImageUtils.generateUrl(
-                      file: event.newNewPhotosExpanded?.first,
+                      file: event.newNewPhotosExpanded?.firstOrNull,
                       imageConfig: ImageConfig.eventPhoto,
                     ),
                   ),

--- a/lib/core/presentation/pages/event/event_detail_page/guest_event_detail_page/widgets/guest_event_detail_about_card.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/guest_event_detail_page/widgets/guest_event_detail_about_card.dart
@@ -29,7 +29,7 @@ class GuestEventDetailAboutCard extends StatelessWidget {
     }
 
     return ImageUtils.generateUrl(
-      file: event.newNewPhotosExpanded?.first,
+      file: event.newNewPhotosExpanded?.firstOrNull,
       imageConfig: ImageConfig.eventPhoto,
     );
   }

--- a/lib/core/presentation/pages/event/event_detail_page/guest_event_detail_page/widgets/guest_event_detail_basic_info.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/guest_event_detail_page/widgets/guest_event_detail_basic_info.dart
@@ -118,14 +118,14 @@ class _EventCountDown extends StatelessWidget {
                                 ),
                                 child: CachedNetworkImage(
                                   fit: BoxFit.cover,
-                                  imageUrl: event.newNewPhotosExpanded
-                                              ?.isNotEmpty ==
-                                          true
-                                      ? ImageUtils.generateUrl(
-                                          file:
-                                              event.newNewPhotosExpanded?.first,
-                                        )
-                                      : '',
+                                  imageUrl:
+                                      event.newNewPhotosExpanded?.isNotEmpty ==
+                                              true
+                                          ? ImageUtils.generateUrl(
+                                              file: event.newNewPhotosExpanded
+                                                  ?.firstOrNull,
+                                            )
+                                          : '',
                                   errorWidget: (context, url, error) =>
                                       ImagePlaceholder.defaultPlaceholder(),
                                   placeholder: (context, url) =>

--- a/lib/core/presentation/pages/event/event_detail_page/guest_event_detail_page/widgets/guest_event_detail_hosts.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/guest_event_detail_page/widgets/guest_event_detail_hosts.dart
@@ -154,7 +154,7 @@ class _EventHostItem extends StatelessWidget {
                               imageUrl: ImageUtils.generateUrl(
                                 file:
                                     host?.newPhotosExpanded?.isNotEmpty == true
-                                        ? host?.newPhotosExpanded?.first
+                                        ? host?.newPhotosExpanded?.firstOrNull
                                         : null,
                                 imageConfig: ImageConfig.eventPhoto,
                               ),

--- a/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/host_event_publish_flow_page/widgets/checklist_items/event_publish_cohosts_checklist_item.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/host_event_publish_flow_page/widgets/checklist_items/event_publish_cohosts_checklist_item.dart
@@ -86,7 +86,7 @@ class _CohostItem extends StatelessWidget {
                   height: Sizing.xSmall,
                   imageUrl: host.newPhotosExpanded?.isNotEmpty == true
                       ? ImageUtils.generateUrl(
-                          file: host.newPhotosExpanded?.first,
+                          file: host.newPhotosExpanded?.firstOrNull,
                         )
                       : '',
                   placeholder: (_, __) => ImagePlaceholder.defaultPlaceholder(),

--- a/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/host_event_publish_flow_page/widgets/checklist_items/event_publish_speakers_checklist_item.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/host_event_publish_flow_page/widgets/checklist_items/event_publish_speakers_checklist_item.dart
@@ -108,7 +108,7 @@ class _SpeakerItem extends StatelessWidget {
                   height: Sizing.xSmall,
                   imageUrl: speaker.newPhotosExpanded?.isNotEmpty == true
                       ? ImageUtils.generateUrl(
-                          file: speaker.newPhotosExpanded?.first,
+                          file: speaker.newPhotosExpanded?.firstOrNull,
                         )
                       : '',
                   placeholder: (_, __) => ImagePlaceholder.defaultPlaceholder(),

--- a/lib/core/presentation/pages/event/widgets/event_card_widget.dart
+++ b/lib/core/presentation/pages/event/widgets/event_card_widget.dart
@@ -78,7 +78,7 @@ class EventCard extends StatelessWidget {
             placeholder: (_, __) => ImagePlaceholder.eventCard(),
             errorWidget: (_, __, ___) => ImagePlaceholder.eventCard(),
             imageUrl: ImageUtils.generateUrl(
-              file: event.newNewPhotosExpanded?.first,
+              file: event.newNewPhotosExpanded?.firstOrNull,
               imageConfig: ImageConfig.eventPhoto,
             ),
           ),

--- a/lib/core/presentation/pages/notification/widgets/notification_card_widget.dart
+++ b/lib/core/presentation/pages/notification/widgets/notification_card_widget.dart
@@ -123,7 +123,7 @@ class NotificationCardView extends StatelessWidget {
         padding: EdgeInsets.only(right: Spacing.small),
         child: LemonCircleAvatar(
           url: ImageUtils.generateUrl(
-            file: notification.fromExpanded?.newPhotosExpanded?.first,
+            file: notification.fromExpanded?.newPhotosExpanded?.firstOrNull,
             imageConfig: ImageConfig.profile,
           ),
           size: 42,


### PR DESCRIPTION
## Overview

- Fix crash in notifications screen
- Fix some existing code can causing crash because newPhotosExpanded

## Issue

https://trello.com/c/pNosx0eP/546-crash-when-landing-on-notification-page-using-kc-account-on-production-env