### PR TITLE
fix: show started event text info

### DIFF
--- a/lib/i18n/event/event_en.i18n.json
+++ b/lib/i18n/event/event_en.i18n.json
@@ -23,6 +23,7 @@
     "processing": "Processing...",
     "aboutTheEvent": "About the event",
     "eventStartIn": "Starting in $time",
+    "eventStartedDaysAgo": "Started ${days}d ago",
     "eventEnded": "Event ended",
     "myEvents": "My events",
     "dashboard": {


### PR DESCRIPTION
## Overview

[Trello ticket](https://trello.com/c/J3bIFJ4x/568-event-detail-shows-event-ended-status-but-the-event-is-still-live)

## Demo

![Screenshot 2024-05-22 at 15 48 25](https://github.com/lemonadesocial/lemonade-flutter/assets/7247063/5238eb34-82e5-4d13-aa68-50609321debe)
