### PR TITLE
fix: update started event label display

### DIFF
--- a/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/widgets/host_event_basic_info_card.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/widgets/host_event_basic_info_card.dart
@@ -41,7 +41,7 @@ class HostEventBasicInfoCard extends StatelessWidget {
       final Duration difference = now.difference(event.start!);
       final int days = difference.inDays;
       if (days == 0) {
-        return t.event.eventStartedYesterday;
+        return t.event.eventStarted;
       }
       return t.event.eventStartedDaysAgo(days: days);
     }

--- a/lib/i18n/event/event_en.i18n.json
+++ b/lib/i18n/event/event_en.i18n.json
@@ -24,7 +24,7 @@
     "aboutTheEvent": "About the event",
     "eventStartIn": "Starting in $time",
     "eventStartedDaysAgo": "Started ${days}d ago",
-    "eventStartedYesterday": "Started yesterday",
+    "eventStarted": "Event started",
     "eventEnded": "Event ended",
     "myEvents": "My events",
     "dashboard": {


### PR DESCRIPTION
## Overview

- https://trello.com/c/bCq7Weib/583-update-the-title-to-event-started-on-the-event-detail-page-when-the-event-is-live