### PR TITLE
fix: add missing ethereum_relay enum

### DIFF
--- a/lib/core/domain/payment/payment_enums.dart
+++ b/lib/core/domain/payment/payment_enums.dart
@@ -13,6 +13,8 @@ enum PaymentAccountType {
   digital,
   @JsonValue('ethereum_escrow')
   ethereumEscrow,
+  @JsonValue('ethereum_relay')
+  ethereumRelay,
 }
 
 enum PaymentState {


### PR DESCRIPTION
## Overview

- fix: [App stuck when open event](https://trello.com/c/7bXRr4oe/606-app-stuck-when-open-event-public-has-application-form)