### PR TITLE
feat: pop close after update personal or social success

### DIFF
--- a/lib/core/presentation/pages/edit_profile/sub_pages/edit_profile_personal_page.dart
+++ b/lib/core/presentation/pages/edit_profile/sub_pages/edit_profile_personal_page.dart
@@ -13,6 +13,7 @@ import 'package:app/theme/color.dart';
 import 'package:app/theme/sizing.dart';
 import 'package:app/theme/spacing.dart';
 import 'package:app/theme/typo.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:app/core/utils/date_utils.dart' as date_utils;
@@ -46,6 +47,7 @@ class EditProfilePersonalDialogState extends State<EditProfilePersonalDialog> {
     return BlocListener<EditProfileBloc, EditProfileState>(
       listener: (context, state) {
         if (state.status == EditProfileStatus.success) {
+          AutoRouter.of(context).pop();
           context.read<AuthBloc>().add(const AuthEvent.refreshData());
           SnackBarUtils.showSuccess(message: t.profile.editProfileSuccess);
           context.read<EditProfileBloc>().add(EditProfileEvent.clearState());

--- a/lib/core/presentation/pages/edit_profile/sub_pages/edit_profile_social_page.dart
+++ b/lib/core/presentation/pages/edit_profile/sub_pages/edit_profile_social_page.dart
@@ -12,6 +12,7 @@ import 'package:app/i18n/i18n.g.dart';
 import 'package:app/theme/sizing.dart';
 import 'package:app/theme/spacing.dart';
 import 'package:app/theme/typo.dart';
+import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
@@ -27,6 +28,7 @@ class EditProfileSocialDialog extends StatelessWidget with LemonBottomSheet {
     return BlocListener<EditProfileBloc, EditProfileState>(
       listener: (context, state) {
         if (state.status == EditProfileStatus.success) {
+          AutoRouter.of(context).pop();
           context.read<AuthBloc>().add(const AuthEvent.refreshData());
           SnackBarUtils.showSuccess(message: t.profile.editProfileSuccess);
           context.read<EditProfileBloc>().add(EditProfileEvent.clearState());


### PR DESCRIPTION
## Overview

- [Close pop up after update successfully](https://trello.com/c/tbGbN0Gn/629-edit-profile-social-handles-and-personal-information-should-close-the-popup-after-editing-infor-successful)

## Demo

https://github.com/lemonadesocial/lemonade-flutter/assets/7247063/0b71250d-6e7c-4819-ba09-20a12151aadd

