### PR TITLE
feat: implement claim relay payment split

### DIFF
--- a/lib/core/application/event_tickets/buy_tickets_with_crypto_bloc/buy_tickets_with_crypto_bloc.dart
+++ b/lib/core/application/event_tickets/buy_tickets_with_crypto_bloc/buy_tickets_with_crypto_bloc.dart
@@ -238,6 +238,9 @@ class BuyTicketsWithCryptoBloc
             );
           }
           _erc20approveTxHash = txHash;
+          await Future.delayed(
+            Duration(seconds: chain?.completedBlockTime ?? 1),
+          );
           final receipt = await Web3Utils.waitForReceipt(
             rpcUrl: chain?.rpcUrl ?? '',
             txHash: _erc20approveTxHash!,

--- a/lib/core/application/payment/connect_payment_account_bloc/connect_payment_account_bloc.dart
+++ b/lib/core/application/payment/connect_payment_account_bloc/connect_payment_account_bloc.dart
@@ -2,7 +2,6 @@ import 'package:app/core/domain/event/entities/event.dart';
 import 'package:app/core/domain/event/event_repository.dart';
 import 'package:app/core/domain/payment/entities/payment_account/payment_account.dart';
 import 'package:app/core/domain/payment/input/create_payment_account_input/create_payment_account_input.dart';
-import 'package:app/core/domain/payment/input/get_payment_accounts_input/get_payment_accounts_input.dart';
 import 'package:app/core/domain/payment/payment_enums.dart';
 import 'package:app/core/domain/payment/payment_repository.dart';
 import 'package:app/core/domain/web3/entities/chain.dart';
@@ -33,7 +32,6 @@ class ConnectPaymentAccountBloc
   ) async {
     emit(ConnectPaymentAccountState.checkingPaymentAccount());
     final connectedPaymentAccounts = _getConnectedPaymentAccounts();
-    final userPaymentAccounts = await _getUserPaymentAccounts();
     final selectedCurrency = blocEvent.currency;
     final selectedChain = blocEvent.selectedChain;
     final userWalletAddress = blocEvent.userWalletAddress;
@@ -51,7 +49,7 @@ class ConnectPaymentAccountBloc
     // if not connected,
     // check if user already created with desired payment account
     final createdPaymentAccount = _getCreatedPaymentAccount(
-      userPaymentAccounts: userPaymentAccounts,
+      connectedPaymentAccounts: connectedPaymentAccounts,
       currency: selectedCurrency,
       selectedChain: selectedChain,
     );
@@ -174,32 +172,24 @@ class ConnectPaymentAccountBloc
   }
 
   PaymentAccount? _getCreatedPaymentAccount({
-    required List<PaymentAccount> userPaymentAccounts,
+    required List<PaymentAccount> connectedPaymentAccounts,
+    // required List<PaymentAccount> userPaymentAccounts,
     required String currency,
     Chain? selectedChain,
   }) {
     PaymentAccount? createdPaymentAccount;
     if (selectedChain != null) {
+      // Each event will have its own relay payment account for each network
       createdPaymentAccount = EventTicketUtils.findEthereumPaymentAccount(
-        userPaymentAccounts,
+        connectedPaymentAccounts,
         network: selectedChain.chainId ?? '',
         currency: currency,
       );
     } else {
       createdPaymentAccount =
-          EventTicketUtils.findStripePaymentAccount(userPaymentAccounts);
+          EventTicketUtils.findStripePaymentAccount(connectedPaymentAccounts);
     }
     return createdPaymentAccount;
-  }
-
-  Future<List<PaymentAccount>> _getUserPaymentAccounts() async {
-    final result = await _paymentRepository.getPaymentAccounts(
-      input: GetPaymentAccountsInput(),
-    );
-    if (result.isLeft()) {
-      return [];
-    }
-    return result.getOrElse(() => []);
   }
 
   List<PaymentAccount> _getConnectedPaymentAccounts() {

--- a/lib/core/data/web3/dtos/chain_dto.dart
+++ b/lib/core/data/web3/dtos/chain_dto.dart
@@ -29,6 +29,7 @@ class ERC20TokenDto with _$ERC20TokenDto {
     String? symbol,
     double? decimals,
     String? contract,
+    @JsonKey(name: 'logo_url') String? logoUrl,
   }) = _ERC20TokenDto;
 
   factory ERC20TokenDto.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/data/web3/web3_query.dart
+++ b/lib/core/data/web3/web3_query.dart
@@ -16,6 +16,7 @@ final getChainsListQuery = gql('''
         symbol
         decimals
         contract
+        logo_url
       }
       relay_payment_contract
     }

--- a/lib/core/domain/web3/entities/chain.dart
+++ b/lib/core/domain/web3/entities/chain.dart
@@ -7,6 +7,8 @@ part 'chain.freezed.dart';
 
 @freezed
 class Chain with _$Chain {
+  Chain._();
+
   factory Chain({
     bool? active,
     String? chainId,
@@ -20,6 +22,9 @@ class Chain with _$Chain {
     double? safeConfirmations,
     String? relayPaymentContract,
   }) = _Chain;
+
+  int get completedBlockTime =>
+      (blockTime?.toInt() ?? 1) * (safeConfirmations?.toInt() ?? 1);
 
   factory Chain.fromDto(ChainDto dto) {
     final tokens = List.from(dto.tokens ?? [])
@@ -54,6 +59,7 @@ class ERC20Token with _$ERC20Token {
     String? symbol,
     double? decimals,
     String? contract,
+    String? logoUrl,
   }) = _ERC20Token;
 
   factory ERC20Token.fromDto(ERC20TokenDto dto) => ERC20Token(
@@ -62,5 +68,6 @@ class ERC20Token with _$ERC20Token {
         symbol: dto.symbol,
         decimals: dto.decimals,
         contract: dto.contract,
+        logoUrl: dto.logoUrl,
       );
 }

--- a/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/claimd_split_relay_payment_page/claim_split_relay_payment_page.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/claimd_split_relay_payment_page/claim_split_relay_payment_page.dart
@@ -1,0 +1,169 @@
+import 'package:app/core/application/wallet/wallet_bloc/wallet_bloc.dart';
+import 'package:app/core/domain/event/entities/event.dart';
+import 'package:app/core/domain/event/entities/event_currency.dart';
+import 'package:app/core/domain/event/input/get_event_currencies_input/get_event_currencies_input.dart';
+import 'package:app/core/domain/event/repository/event_ticket_repository.dart';
+import 'package:app/core/domain/web3/entities/chain.dart';
+import 'package:app/core/domain/web3/web3_repository.dart';
+import 'package:app/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/claimd_split_relay_payment_page/widgets/claim_payment_by_network_group_widget.dart';
+import 'package:app/core/presentation/widgets/common/appbar/lemon_appbar_widget.dart';
+import 'package:app/core/presentation/widgets/common/list/empty_list_widget.dart';
+import 'package:app/core/presentation/widgets/loading_widget.dart';
+import 'package:app/core/presentation/widgets/web3/connect_wallet_button.dart';
+import 'package:app/gen/fonts.gen.dart';
+import 'package:app/i18n/i18n.g.dart';
+import 'package:app/injection/register_module.dart';
+import 'package:app/theme/spacing.dart';
+import 'package:app/theme/typo.dart';
+import 'package:auto_route/auto_route.dart';
+import 'package:flutter/material.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+
+@RoutePage()
+class ClaimSplitRelayPaymentPage extends StatelessWidget {
+  final Event event;
+  const ClaimSplitRelayPaymentPage({
+    super.key,
+    required this.event,
+  });
+
+  Future<Map<Chain, List<EventCurrency>>>
+      getAllCurrenciesGroupByNetwork() async {
+    final chains = (await getIt<Web3Repository>().getChainsList()).fold(
+      (l) => [] as List<Chain>,
+      (r) => r,
+    );
+
+    final currencies = (await getIt<EventTicketRepository>().getEventCurrencies(
+      input: GetEventCurrenciesInput(
+        id: event.id ?? '',
+      ),
+    ))
+        .fold(
+      (l) => [] as List<EventCurrency>,
+      (r) => r.where((element) => element.network?.isNotEmpty == true),
+    );
+    return groupBy<EventCurrency, Chain>(
+      currencies,
+      (currency) {
+        return chains.firstWhereOrNull(
+              (chain) => chain.chainId == currency.network,
+            ) ??
+            Chain();
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final t = Translations.of(context);
+    final colorScheme = Theme.of(context).colorScheme;
+    return Scaffold(
+      body: SafeArea(
+        child: BlocBuilder<WalletBloc, WalletState>(
+          builder: (context, state) {
+            return FutureBuilder(
+              future: getAllCurrenciesGroupByNetwork(),
+              builder: (context, snapshot) {
+                final isConnected = state.activeSession != null;
+                return CustomScrollView(
+                  slivers: [
+                    const SliverToBoxAdapter(
+                      child: LemonAppBar(),
+                    ),
+                    SliverPadding(
+                      padding: EdgeInsets.symmetric(horizontal: Spacing.small),
+                      sliver: SliverToBoxAdapter(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Text(
+                              t.event.relayPayment.claimSplit.claimSplitTitle,
+                              style: Typo.extraLarge.copyWith(
+                                color: colorScheme.onPrimary,
+                                fontWeight: FontWeight.w700,
+                                fontFamily: FontFamily.nohemiVariable,
+                              ),
+                            ),
+                            SizedBox(height: Spacing.superExtraSmall),
+                            Text(
+                              t.event.relayPayment.claimSplit
+                                  .claimSplitDescription,
+                              style: Typo.mediumPlus.copyWith(
+                                color: colorScheme.onSecondary,
+                              ),
+                            ),
+                            SizedBox(height: Spacing.large),
+                          ],
+                        ),
+                      ),
+                    ),
+                    if (!isConnected)
+                      SliverPadding(
+                        padding:
+                            EdgeInsets.symmetric(horizontal: Spacing.small),
+                        sliver: const SliverToBoxAdapter(
+                          child: ConnectWalletButton(),
+                        ),
+                      ),
+                    if (isConnected)
+                      SliverPadding(
+                        padding:
+                            EdgeInsets.symmetric(horizontal: Spacing.small),
+                        sliver: Builder(
+                          builder: (context) {
+                            if (snapshot.connectionState ==
+                                ConnectionState.waiting) {
+                              return SliverToBoxAdapter(
+                                child: Center(
+                                  child: Loading.defaultLoading(context),
+                                ),
+                              );
+                            }
+
+                            if (snapshot.data == null) {
+                              return const SliverToBoxAdapter(
+                                child: Center(
+                                  child: EmptyList(),
+                                ),
+                              );
+                            }
+
+                            final currenciesByNetwork = snapshot.data
+                                as Map<Chain, List<EventCurrency>>;
+
+                            if (currenciesByNetwork.entries.isEmpty) {
+                              return const SliverToBoxAdapter(
+                                child: Center(
+                                  child: EmptyList(),
+                                ),
+                              );
+                            }
+                            return SliverList.separated(
+                              itemCount: currenciesByNetwork.entries.length,
+                              itemBuilder: (context, index) {
+                                final group =
+                                    currenciesByNetwork.entries.toList()[index];
+                                return ClaimPaymentByNetworkGroup(
+                                  event: event,
+                                  chain: group.key,
+                                  currencies: group.value,
+                                );
+                              },
+                              separatorBuilder: (context, index) =>
+                                  SizedBox(height: Spacing.xSmall),
+                            );
+                          },
+                        ),
+                      ),
+                  ],
+                );
+              },
+            );
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/claimd_split_relay_payment_page/widgets/claim_payment_by_network_group_widget.dart
+++ b/lib/core/presentation/pages/event/event_detail_page/host_event_detail_page/sub_pages/claimd_split_relay_payment_page/widgets/claim_payment_by_network_group_widget.dart
@@ -1,0 +1,304 @@
+import 'package:app/core/domain/event/entities/event.dart';
+import 'package:app/core/domain/event/entities/event_currency.dart';
+import 'package:app/core/domain/payment/entities/payment_account/payment_account.dart';
+import 'package:app/core/domain/payment/payment_enums.dart';
+import 'package:app/core/domain/web3/entities/chain.dart';
+import 'package:app/core/presentation/widgets/common/button/linear_gradient_button_widget.dart';
+import 'package:app/core/presentation/widgets/common/dotted_line/dotted_line.dart';
+import 'package:app/core/presentation/widgets/lemon_network_image/lemon_network_image.dart';
+import 'package:app/core/presentation/widgets/loading_widget.dart';
+import 'package:app/core/service/wallet/wallet_connect_service.dart';
+import 'package:app/core/service/web3/lemonade_relay/lemonade_relay_utils.dart';
+import 'package:app/core/utils/snackbar_utils.dart';
+import 'package:app/core/utils/web3_utils.dart';
+import 'package:app/i18n/i18n.g.dart';
+import 'package:app/injection/register_module.dart';
+import 'package:app/theme/color.dart';
+import 'package:app/theme/sizing.dart';
+import 'package:app/theme/spacing.dart';
+import 'package:app/theme/typo.dart';
+import 'package:flutter/material.dart';
+import 'package:collection/collection.dart';
+import 'package:flutter_screenutil/flutter_screenutil.dart';
+import 'package:web3modal_flutter/web3modal_flutter.dart' as web3modal;
+
+class ClaimbleRelayPayment {
+  final BigInt amount;
+  final ERC20Token token;
+
+  ClaimbleRelayPayment({
+    required this.amount,
+    required this.token,
+  });
+}
+
+class ClaimPaymentByNetworkGroup extends StatefulWidget {
+  final Event event;
+  final Chain chain;
+  final List<EventCurrency> currencies;
+  const ClaimPaymentByNetworkGroup({
+    super.key,
+    required this.event,
+    required this.chain,
+    required this.currencies,
+  });
+
+  @override
+  State<ClaimPaymentByNetworkGroup> createState() =>
+      _ClaimPaymentByNetworkGroupState();
+}
+
+class _ClaimPaymentByNetworkGroupState
+    extends State<ClaimPaymentByNetworkGroup> {
+  bool isClaiming = false;
+
+  PaymentAccount? get targetPaymentAccount {
+    return widget.event.paymentAccountsExpanded?.firstWhereOrNull(
+      (account) =>
+          account.accountInfo?.network == widget.chain.chainId &&
+          account.type == PaymentAccountType.ethereumRelay,
+    );
+  }
+
+  Future<void> claimSplit(List<ClaimbleRelayPayment> claimablePayments) async {
+    setState(() {
+      isClaiming = true;
+    });
+    final tokens = claimablePayments
+        .where((item) => item.amount != BigInt.zero)
+        .map(
+          (e) => e.token,
+        )
+        .toList();
+    final result = await LemonadeRelayUtils.claimSplit(
+      paymentSplitterContractAddress:
+          targetPaymentAccount?.accountInfo?.paymentSplitterContract ?? '',
+      connectedWalletAddress:
+          getIt<WalletConnectService>().w3mService.session?.address ?? '',
+      chain: widget.chain,
+      tokens: tokens,
+    );
+    result.fold(
+      (failure) {
+        SnackBarUtils.showError(
+          message: failure.message ??
+              t.event.relayPayment.claimSplit.claimSplitFailed,
+        );
+      },
+      (r) => SnackBarUtils.showSuccess(
+        message: t.event.relayPayment.claimSplit.claimSplitSuccess,
+      ),
+    );
+    if (mounted) {
+      setState(() {
+        isClaiming = false;
+      });
+    }
+  }
+
+  Future<List<ClaimbleRelayPayment>> getClaimablePayments() async {
+    final userWalletAddress = targetPaymentAccount?.accountInfo?.address ?? '';
+    final tokens = widget.currencies
+        .map((item) {
+          final targetToken = widget.chain.tokens?.firstWhereOrNull(
+            (token) => token.symbol == item.currency,
+          );
+          return targetToken;
+        })
+        .whereType<ERC20Token>()
+        .toList();
+    final amounts = (await LemonadeRelayUtils.getClaimables(
+      tokens: tokens,
+      chain: widget.chain,
+      paymentSplitterContractAddress:
+          targetPaymentAccount?.accountInfo?.paymentSplitterContract ?? '',
+      userWalletAddress: userWalletAddress,
+    ))
+        .fold((l) => [] as List<BigInt>, (r) => r);
+
+    final payments = tokens.asMap().entries.map((entry) {
+      final index = entry.key;
+      return ClaimbleRelayPayment(amount: amounts[index], token: entry.value);
+    }).toList();
+    return payments;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final colorScheme = Theme.of(context).colorScheme;
+    final t = Translations.of(context);
+    return FutureBuilder(
+      future: getClaimablePayments(),
+      builder: (context, snapshot) {
+        final claimablePayments = snapshot.data ?? [];
+        final isAllClaimed =
+            claimablePayments.every((element) => element.amount == BigInt.zero);
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Container(
+              padding: EdgeInsets.all(Spacing.small),
+              width: double.infinity,
+              decoration: BoxDecoration(
+                color: LemonColor.atomicBlack,
+                borderRadius: BorderRadius.only(
+                  topLeft: Radius.circular(LemonRadius.medium),
+                  topRight: Radius.circular(LemonRadius.medium),
+                ),
+              ),
+              child: Row(
+                children: [
+                  Container(
+                    width: Sizing.medium,
+                    height: Sizing.medium,
+                    decoration: ShapeDecoration(
+                      color: LemonColor.chineseBlack,
+                      shape: const CircleBorder(),
+                    ),
+                    child: Center(
+                      child: LemonNetworkImage(
+                        imageUrl: widget.chain.logoUrl ?? '',
+                        width: Sizing.mSmall,
+                        height: Sizing.mSmall,
+                        borderRadius: BorderRadius.circular(Sizing.medium),
+                      ),
+                    ),
+                  ),
+                  SizedBox(width: Spacing.xSmall),
+                  Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text(
+                        widget.chain.name ?? '',
+                        style: Typo.medium.copyWith(
+                          color: colorScheme.onPrimary,
+                        ),
+                      ),
+                      if (!isAllClaimed)
+                        Text(
+                          t.event.relayPayment.claimSplit.pendingClaims,
+                          style: Typo.small.copyWith(
+                            color: LemonColor.malachiteGreen,
+                          ),
+                        ),
+                    ],
+                  ),
+                  const Spacer(),
+                  if (!isAllClaimed)
+                    SizedBox(
+                      height: Sizing.medium,
+                      child: LinearGradientButton.primaryButton(
+                        loadingWhen: isClaiming,
+                        label: t.common.actions.claim,
+                        onTap: () {
+                          if (isClaiming) return;
+                          claimSplit(claimablePayments);
+                        },
+                        textStyle: Typo.small.copyWith(
+                          color: colorScheme.onPrimary,
+                          fontWeight: FontWeight.w600,
+                        ),
+                      ),
+                    ),
+                ],
+              ),
+            ),
+            Container(
+              width: double.infinity,
+              padding: EdgeInsets.all(Spacing.small),
+              decoration: BoxDecoration(
+                color: LemonColor.chineseBlack,
+                borderRadius: BorderRadius.only(
+                  bottomLeft: Radius.circular(LemonRadius.medium),
+                  bottomRight: Radius.circular(LemonRadius.medium),
+                ),
+              ),
+              child: Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  if (snapshot.connectionState == ConnectionState.waiting &&
+                      claimablePayments.isEmpty)
+                    Loading.defaultLoading(context),
+                  for (final item in claimablePayments.asMap().entries)
+                    _ClaimableItem(
+                      isLast: item.key == claimablePayments.length - 1,
+                      claimableRelayPayment: item.value,
+                    ),
+                ],
+              ),
+            ),
+          ],
+        );
+      },
+    );
+  }
+}
+
+class _ClaimableItem extends StatelessWidget {
+  final ClaimbleRelayPayment claimableRelayPayment;
+  final bool isLast;
+  const _ClaimableItem({
+    required this.isLast,
+    required this.claimableRelayPayment,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final targetToken = claimableRelayPayment.token;
+    final colorScheme = Theme.of(context).colorScheme;
+    return Container(
+      margin: EdgeInsets.only(bottom: isLast ? 0 : Spacing.xSmall),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.center,
+        children: [
+          LemonNetworkImage(
+            imageUrl: targetToken.logoUrl ?? '',
+            width: Sizing.mSmall,
+            height: Sizing.mSmall,
+            borderRadius: BorderRadius.circular(Sizing.medium),
+            placeholder: Container(
+              width: Sizing.mSmall,
+              height: Sizing.mSmall,
+              decoration: ShapeDecoration(
+                color: LemonColor.atomicBlack,
+                shape: const CircleBorder(),
+              ),
+            ),
+          ),
+          SizedBox(width: Spacing.extraSmall),
+          Text(
+            targetToken.symbol ?? '',
+            style: Typo.medium.copyWith(
+              color: colorScheme.onSecondary,
+            ),
+          ),
+          SizedBox(
+            width: Spacing.superExtraSmall,
+          ),
+          Expanded(
+            child: Container(
+              margin: EdgeInsets.only(top: 10.w),
+              child: DottedLine(
+                dashColor: colorScheme.outline,
+              ),
+            ),
+          ),
+          SizedBox(
+            width: Spacing.superExtraSmall,
+          ),
+          Text(
+            Web3Utils.formatCryptoCurrency(
+              claimableRelayPayment.amount,
+              currency: targetToken.symbol ?? '',
+              decimals: targetToken.decimals?.toInt() ?? 18,
+            ),
+            style: Typo.medium.copyWith(
+              color: colorScheme.onSecondary,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/core/service/web3/lemonade_relay/contracts/lemonade_payment_splitter_contract_abi.dart
+++ b/lib/core/service/web3/lemonade_relay/contracts/lemonade_payment_splitter_contract_abi.dart
@@ -1,0 +1,419 @@
+const lemonadePaymentSplitterContractAbi = '''
+ [
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "payees",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint256[]",
+          "name": "shares_",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "payable",
+      "type": "constructor"
+    },
+    {
+      "inputs": [],
+      "name": "AccountHasNoShare",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "AccountHasShare",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidAddress",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidShare",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "LengthMismatch",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "NoDueAmount",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ZeroLength",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "ERC20PaymentReleased",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "shares",
+          "type": "uint256"
+        }
+      ],
+      "name": "PayeeAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [],
+      "name": "PayeesReset",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "from",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "PaymentReceived",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "PaymentReleased",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "allPayees",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "shares",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct Payee[]",
+          "name": "payees",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "pending",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "currencies",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "pending",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "balances",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "pending",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address payable",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "release",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "release",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "currencies",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address payable",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "release",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address[]",
+          "name": "currencies",
+          "type": "address[]"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "released",
+      "outputs": [
+        {
+          "internalType": "uint256[]",
+          "name": "balances",
+          "type": "uint256[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "released",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "released",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "shares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "totalReleased",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalReleased",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalShares",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "stateMutability": "payable",
+      "type": "receive"
+    }
+  ]
+''';

--- a/lib/core/service/web3/lemonade_relay/lemonade_relay_utils.dart
+++ b/lib/core/service/web3/lemonade_relay/lemonade_relay_utils.dart
@@ -3,11 +3,13 @@ import 'package:app/core/domain/web3/entities/ethereum_transaction.dart';
 import 'package:app/core/failure.dart';
 import 'package:app/core/service/wallet/wallet_connect_service.dart';
 import 'package:app/core/service/web3/web3_contract_service.dart';
+import 'package:app/core/utils/web3_utils.dart';
 import 'package:app/injection/register_module.dart';
 import 'package:convert/convert.dart';
 import 'package:dartz/dartz.dart';
 import 'package:web3dart/web3dart.dart';
 import 'package:http/http.dart' as http;
+import 'package:collection/collection.dart';
 
 class LemonadeRelayUtils {
   static Future<Either<Failure, String>> register({
@@ -39,26 +41,149 @@ class LemonadeRelayUtils {
         chainId: chain.fullChainId ?? '',
         transaction: ethTx,
       );
-      String? paymentSplitter = '';
-      int attempt = 0;
-      final web3Client = Web3Client(
-        chain.rpcUrl ?? '',
-        http.Client(),
+      await Future.delayed(
+        Duration(seconds: chain.completedBlockTime),
       );
-      while (paymentSplitter?.isEmpty == true || attempt < 5) {
-        await Future.delayed(const Duration(seconds: 3));
-        final receipt = await web3Client.getTransactionReceipt(txId);
-        if (receipt?.logs.isNotEmpty == true) {
-          paymentSplitter = receipt?.logs[0].address.toString();
-          if (paymentSplitter?.isNotEmpty == true) {
-            return Right(paymentSplitter!);
-          }
+      String? paymentSplitter = '';
+      final receipt = await Web3Utils.waitForReceipt(
+        rpcUrl: chain.rpcUrl ?? '',
+        txHash: txId,
+        deplayDuration: const Duration(seconds: 3),
+      );
+      if (receipt?.logs.isNotEmpty == true) {
+        paymentSplitter = receipt?.logs[0].address.toString();
+        if (paymentSplitter?.isNotEmpty == true) {
+          return Right(paymentSplitter!);
         }
-        attempt++;
       }
       return Left(Failure());
     } catch (e) {
       return Left(Failure());
+    }
+  }
+
+  static Future<EthereumAddress> _getPayeeAddress({
+    required Chain chain,
+    required String paymentSplitterContractAddress,
+  }) async {
+    final contract = Web3ContractService.getPaymentSplitterContract(
+      paymentSplitterContractAddress,
+    );
+    final web3Client = Web3Client(chain.rpcUrl!, http.Client());
+    final data = await web3Client.call(
+      contract: contract,
+      function: contract.function('allPayees'),
+      params: [],
+    );
+    final payees = data[0];
+    // currently only get first payee because we only support 1 payee (event's host)
+    return payees[0][0] as EthereumAddress;
+  }
+
+  static Future<Either<Failure, bool>> claimSplit({
+    required String paymentSplitterContractAddress,
+    required String connectedWalletAddress,
+    required Chain chain,
+    required List<ERC20Token> tokens,
+  }) async {
+    try {
+      final contract = Web3ContractService.getPaymentSplitterContract(
+        paymentSplitterContractAddress,
+      );
+      final releaseFunctionWithMultiToken =
+          contract.functions.firstWhere((func) {
+        final targetParam = func.parameters
+            .firstWhereOrNull((element) => element.name == 'currencies');
+        return func.name == 'release' && targetParam != null;
+      });
+
+      final payeeAddress = await _getPayeeAddress(
+        chain: chain,
+        paymentSplitterContractAddress: paymentSplitterContractAddress,
+      );
+      final contractCallTx = Transaction.callContract(
+        contract: contract,
+        function: releaseFunctionWithMultiToken,
+        parameters: [
+          tokens
+              .map((token) => EthereumAddress.fromHex(token.contract!))
+              .toList(),
+          payeeAddress,
+        ],
+      );
+      final ethereumTx = EthereumTransaction(
+        from: connectedWalletAddress,
+        to: paymentSplitterContractAddress,
+        value: BigInt.zero.toRadixString(16),
+        data: hex.encode(contractCallTx.data!),
+      );
+      final txHash = await getIt<WalletConnectService>().requestTransaction(
+        chainId: chain.fullChainId ?? '',
+        transaction: ethereumTx,
+      );
+      if (!txHash.startsWith('0x')) {
+        return Left(Failure());
+      }
+      await Future.delayed(
+        Duration(seconds: chain.completedBlockTime),
+      );
+      final receipt = await Web3Utils.waitForReceipt(
+        rpcUrl: chain.rpcUrl ?? '',
+        txHash: txHash,
+        deplayDuration: const Duration(seconds: 3),
+      );
+      if (receipt?.status == true) {
+        return const Right(true);
+      }
+      return Left(Failure());
+    } catch (e) {
+      return Left(Failure(message: e.toString()));
+    }
+  }
+
+  static Future<Either<Failure, List<BigInt>>> getClaimables({
+    required String paymentSplitterContractAddress,
+    required String userWalletAddress,
+    required Chain chain,
+    required List<ERC20Token> tokens,
+  }) async {
+    try {
+      final contract = Web3ContractService.getPaymentSplitterContract(
+        paymentSplitterContractAddress,
+      );
+      final pendingFunctionWithMultipleTokens =
+          contract.functions.firstWhere((func) {
+        final targetParam = func.parameters
+            .firstWhereOrNull((element) => element.name == 'currencies');
+        return func.name == 'pending' && targetParam != null;
+      });
+      final web3Client = Web3Client(chain.rpcUrl!, http.Client());
+      // currently only get first payee because we only support 1 payee (event's host)
+      final payeeAddress = await _getPayeeAddress(
+        chain: chain,
+        paymentSplitterContractAddress: paymentSplitterContractAddress,
+      );
+      final tokenAddresses = tokens
+          .map((token) => EthereumAddress.fromHex(token.contract!))
+          .toList();
+      final data = await web3Client.call(
+        contract: contract,
+        function: pendingFunctionWithMultipleTokens,
+        params: [
+          tokenAddresses,
+          payeeAddress,
+        ],
+      );
+
+      final amounts = data.isNotEmpty
+          ? (data[0] as List<dynamic>).whereType<BigInt>().toList()
+          : null;
+      if (amounts != null) {
+        return Right(amounts);
+      }
+      return Left(Failure());
+    } catch (e) {
+      return Left(Failure(message: e.toString()));
     }
   }
 }

--- a/lib/core/service/web3/web3_contract_service.dart
+++ b/lib/core/service/web3/web3_contract_service.dart
@@ -1,6 +1,7 @@
 import 'package:app/core/service/web3/erc20.dart';
 import 'package:app/core/service/web3/escrow/contracts/lemonade_escrow_factory_v1_contract_abi.dart';
 import 'package:app/core/service/web3/escrow/contracts/lemonade_escrow_v1_contract_abi.dart';
+import 'package:app/core/service/web3/lemonade_relay/contracts/lemonade_payment_splitter_contract_abi.dart';
 import 'package:app/core/service/web3/lemonade_relay/contracts/lemonade_relay_payment_contract_abi.dart';
 import 'package:web3dart/web3dart.dart';
 
@@ -29,6 +30,13 @@ class Web3ContractService {
   static DeployedContract getRelayPaymentContract(String contractAddress) {
     return DeployedContract(
       ContractAbi.fromJson(lemonadeRelayPaymentContractAbi, ''),
+      EthereumAddress.fromHex(contractAddress),
+    );
+  }
+
+  static DeployedContract getPaymentSplitterContract(String contractAddress) {
+    return DeployedContract(
+      ContractAbi.fromJson(lemonadePaymentSplitterContractAbi, ''),
       EthereumAddress.fromHex(contractAddress),
     );
   }

--- a/lib/i18n/common/common_en.i18n.json
+++ b/lib/i18n/common/common_en.i18n.json
@@ -65,7 +65,8 @@
         "join": "Join",
         "shareUser": "Share user",
         "reportUser": "Report user",
-        "editMyProfile": "Edit my profile"
+        "editMyProfile": "Edit my profile",
+        "claim": "Claim"
     },
     "followed": "Followed",
     "anonymous": "anonymous",

--- a/lib/i18n/event/event_en.i18n.json
+++ b/lib/i18n/event/event_en.i18n.json
@@ -609,5 +609,15 @@
         "cancelled": "Cancelled",
         "cancelledSuccessfully": "Your event “$event_name” has been successfully cancelled"
     },
-    "cancelTicket": "Cancel ticket"
+    "cancelTicket": "Cancel ticket",
+    "relayPayment": {
+        "claimSplit": {
+            "saleSplit": "Sales split",
+            "claimSplitTitle": "Claim Sales Split",
+            "claimSplitDescription": "You have a sales split from crypto ticket sales. Pay gas fees and claim your share!",
+            "claimSplitSuccess": "Successfully claimed",
+            "claimSplitFailed": "Fail to claim",
+            "pendingClaims": "Pending claims"
+        }
+    }
 }

--- a/lib/router/app_router.dart
+++ b/lib/router/app_router.dart
@@ -184,6 +184,9 @@ final eventDetailRoutes = AutoRoute(
       page: ScanQRCheckinRewardsRoute.page,
     ),
     AutoRoute(
+      page: ClaimSplitRelayPaymentRoute.page,
+    ),
+    AutoRoute(
       path: 'claimRewards/:user_id',
       page: ClaimRewardsRoute.page,
     ),


### PR DESCRIPTION
# What ?
- Implement claim split from relay payment
- Create new payment account for each event instead of reusing the old one (this help you prevent claiming other event revenue)

# Screenshot
<img width="517" alt="Screenshot 2024-07-09 at 08 39 13" src="https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/474dc4d8-a794-4934-9da2-db8c1952ee35">
<img width="517" alt="Screenshot 2024-07-09 at 08 39 16" src="https://github.com/lemonadesocial/lemonade-flutter/assets/28992487/4a12aac8-8d26-4a50-8087-93e5a372270e">
