### PR TITLE
fix: add empty state for nework group in claim split pages

### DIFF
--- a/lib/i18n/event/event_en.i18n.json
+++ b/lib/i18n/event/event_en.i18n.json
@@ -617,7 +617,8 @@
             "claimSplitDescription": "You have a sales split from crypto ticket sales. Pay gas fees and claim your share!",
             "claimSplitSuccess": "Successfully claimed",
             "claimSplitFailed": "Fail to claim",
-            "pendingClaims": "Pending claims"
+            "pendingClaims": "Pending claims",
+            "emptyPendingClaims": "No pending claims"
         }
     }
 }


### PR DESCRIPTION
# What ?
https://trello.com/c/RSnfWCTR/642-claim-split-hide-the-currency-and-add-refresh-icon-if-no-claimable
- Add empty state for network group in claim split pages

# Screenshot 
<img width="410" alt="Screenshot 2024-07-12 at 10 10 57" src="https://github.com/user-attachments/assets/4f7110af-adb8-48df-a1fb-fdc8379d42db">
