### PR TITLE
fix: add use full screen intent sdk34

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -6,6 +6,7 @@
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.VIBRATE" />
   <uses-permission android:name="android.permission.CAMERA" />
+  <uses-permission android:name="android.permission.USE_FULL_SCREEN_INTENT" tools:node="remove" />
   <queries>
     <package android:name="metamask" />
     <package android:name="io.metamask"/>


### PR DESCRIPTION
## Overview
- Unable to upload new version to PlayStore due to required full screen intent permission in target SDK34

<img width="894" alt="Screenshot 2024-08-26 at 09 36 17" src="https://github.com/user-attachments/assets/89e3b790-f696-4760-b6e2-e2b57cca9f53">
