### PR TITLE
fix: prefill parent event location when creating subevent

### DIFF
--- a/lib/core/application/event/create_event_bloc/create_event_bloc.dart
+++ b/lib/core/application/event/create_event_bloc/create_event_bloc.dart
@@ -176,6 +176,8 @@ class CreateEventBloc extends Bloc<CreateEventEvent, CreateEventState> {
                 longitude: event.address!.longitude,
               )
             : null,
+        latitude: event.address?.latitude,
+        longitude: event.address?.longitude,
         published: false,
         subevent_parent: parentEventId,
         subevent_enabled: event.subEventEnabled,

--- a/lib/core/application/event/event_location_setting_bloc/event_location_setting_bloc.dart
+++ b/lib/core/application/event/event_location_setting_bloc/event_location_setting_bloc.dart
@@ -389,20 +389,11 @@ class EventLocationSettingBloc
     SelectAddress event,
     Emitter<EventLocationSettingState> emit,
   ) async {
-    // Uncheck when tap again
-    if (event.address.id == state.selectedAddress?.id) {
-      emit(
-        state.copyWith(
-          selectedAddress: null,
-        ),
-      );
-    } else {
-      emit(
-        state.copyWith(
-          selectedAddress: event.address,
-        ),
-      );
-    }
+    return emit(
+      state.copyWith(
+        selectedAddress: event.address,
+      ),
+    );
   }
 
   Future<void> _onAdditionalDirectionsChanged(

--- a/lib/core/data/event/gql/event_query.dart
+++ b/lib/core/data/event/gql/event_query.dart
@@ -172,10 +172,18 @@ const eventFragment = '''
       provider_id
     }
     address {
+      _id
       street_1
+      street_2
       city
       title
       region
+      country
+      additional_directions
+      latitude
+      longitude
+      postal
+      recipient_name
     }
     latitude
     longitude

--- a/lib/core/presentation/pages/event/create_event/create_event_page.dart
+++ b/lib/core/presentation/pages/event/create_event/create_event_page.dart
@@ -4,12 +4,16 @@ import 'package:app/core/application/event/event_datetime_settings_bloc/event_da
 import 'package:app/core/application/event/event_guest_settings_bloc/event_guest_settings_bloc.dart';
 import 'package:app/core/application/event/event_location_setting_bloc/event_location_setting_bloc.dart';
 import 'package:app/core/constants/event/event_constants.dart';
+import 'package:app/core/domain/common/entities/common.dart';
+import 'package:app/core/domain/event/event_repository.dart';
+import 'package:app/core/domain/event/input/get_event_detail_input.dart';
+import 'package:app/injection/register_module.dart';
 import 'package:auto_route/auto_route.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
 @RoutePage()
-class CreateEventPage extends StatelessWidget implements AutoRouteWrapper {
+class CreateEventPage extends StatefulWidget implements AutoRouteWrapper {
   final String? parentEventId;
   const CreateEventPage({
     super.key,
@@ -50,6 +54,48 @@ class CreateEventPage extends StatelessWidget implements AutoRouteWrapper {
       ],
       child: this,
     );
+  }
+
+  @override
+  State<CreateEventPage> createState() => _CreateEventPageState();
+}
+
+class _CreateEventPageState extends State<CreateEventPage> {
+  @override
+  void initState() {
+    super.initState();
+    _prefillParentEventData();
+  }
+
+  Future<void> _prefillParentEventData() async {
+    if (widget.parentEventId != null) {
+      final result = await getIt<EventRepository>().getEventDetail(
+        input: GetEventDetailInput(id: widget.parentEventId!),
+      );
+      final parentEvent = result.fold(
+        (l) => null,
+        (r) => r,
+      );
+      context.read<EventLocationSettingBloc>().add(
+            EventLocationSettingEvent.selectAddress(
+              address: Address(
+                id: parentEvent?.address?.id,
+                title: parentEvent?.address?.title ?? '',
+                street1: parentEvent?.address?.street1 ?? '',
+                street2: parentEvent?.address?.street2 ?? '',
+                city: parentEvent?.address?.city ?? '',
+                region: parentEvent?.address?.region ?? '',
+                postal: parentEvent?.address?.postal ?? '',
+                country: parentEvent?.address?.country ?? '',
+                latitude: parentEvent?.address?.latitude,
+                longitude: parentEvent?.address?.longitude,
+                additionalDirections:
+                    parentEvent?.address?.additionalDirections ?? '',
+                recipientName: parentEvent?.address?.recipientName ?? '',
+              ),
+            ),
+          );
+    }
   }
 
   @override


### PR DESCRIPTION
# What ?
https://trello.com/c/gU0XPD6N/776-main-event-location-is-automatically-added-to-the-subevent
