### PR TITLE
feat: integrate Lens account statistics into profile info drawer

### DIFF
--- a/lib/graphql/lens/account/mutation/lens_account_stats.graphql
+++ b/lib/graphql/lens/account/mutation/lens_account_stats.graphql
@@ -1,0 +1,18 @@
+query LensAccountStats($request: AccountStatsRequest!) {
+  accountStats(request: $request) {
+    feedStats {
+      posts
+      comments
+      reposts
+      quotes
+      reacted
+      reactions
+      collects
+      tips
+    }
+    graphFollowStats {
+      followers
+      following
+    }
+  }
+}


### PR DESCRIPTION
- Added GraphQL query for Lens account statistics to fetch followers and following counts.
- Updated LemonDrawerProfileInfo widget to conditionally display follower counts based on selected Lens account.