### PR TITLE
fix: update image URL reference in EditProfileViewV2

### DIFF
--- a/lib/core/presentation/pages/edit_profile/edit_profile_view_v2.dart
+++ b/lib/core/presentation/pages/edit_profile/edit_profile_view_v2.dart
@@ -211,7 +211,7 @@ class _EditProfileViewV2State extends State<EditProfileViewV2> {
                               return EditProfileAvatar(
                                 user: lemonadeAccount,
                                 imageFile: state.profilePhoto,
-                                imageUrl: lemonadeAccount?.imageAvatar,
+                                imageUrl: userProfile.imageAvatar,
                               );
                             },
                           ),


### PR DESCRIPTION
- Changed the imageUrl reference in EditProfileAvatar from lemonadeAccount?.imageAvatar to userProfile.imageAvatar for accurate profile image display.