### PR TITLE
fix: update target SDK version in build.gradle

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -23,6 +23,11 @@ if (flutterMinSdk == null) {
     flutterMinSdk = 23
 }
 
+def flutterTargetSdk = localProperties.getProperty('flutter.targetSdk')
+if (flutterTargetSdk == null) {
+    flutterTargetSdk = 35
+}
+
 def flutterVersionCode = localProperties.getProperty('flutter.versionCode')
 if (flutterVersionCode == null) {
     flutterVersionCode = '1'
@@ -76,7 +81,7 @@ android {
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
         minSdk = 23
-        targetSdk = flutter.targetSdkVersion
+        targetSdk = flutterTargetSdk
         versionCode = flutter.versionCode
         versionName = flutter.versionName
 


### PR DESCRIPTION
- Added a new property for flutterTargetSdk to set the target SDK version to 35 if not already defined in local properties.
- Updated the targetSdk assignment in the android block to use flutterTargetSdk for better configuration management.