### PR TITLE
fix: update author display logic in LensPostFeedItemWidget

### DIFF
--- a/lib/core/presentation/pages/lens/widget/lens_post_feed/widgets/lenst_post_feed_item_widget.dart
+++ b/lib/core/presentation/pages/lens/widget/lens_post_feed/widgets/lenst_post_feed_item_widget.dart
@@ -151,7 +151,9 @@ class _LensPostFeedItemWidgetState extends State<LensPostFeedItemWidget>
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                              widget.post.author?.username?.localName ?? '',
+                              widget.post.author?.metadata?.name ??
+                                  widget.post.author?.username?.localName ??
+                                  '',
                               style: appText.md,
                             ),
                             if (widget.post.timestamp != null)


### PR DESCRIPTION
- Modified the author display logic to prioritize the author's metadata name over the username, ensuring a more accurate representation of the author in the post feed.